### PR TITLE
🛡️ Sentinel: Fix XSS and improve secret redaction in logs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,9 @@
+## 2025-05-15 - [Logging: Recursive Secret Redaction]
+**Vulnerability:** Logging utilities (`safeLog`, `safeError`, `safeWarn`) only redacted secrets in top-level string arguments or Error messages. Sensitive data (GitHub PATs) could still be leaked if passed within nested objects or arrays.
+**Learning:** Developers often log complex objects during debugging or for diagnostics. A flat redaction strategy is insufficient. A recursive approach with cycle detection and depth limiting is required to prevent DoS via stack overflow while ensuring security.
+**Prevention:** Always use recursive redaction for any logging utility that might handle sensitive data. Implement `redactAny` with `WeakSet` for cycle detection.
+
+## 2025-05-15 - [XSS: Unescaped Language Class]
+**Vulnerability:** In `gist-detail.ts`, the `renderFileContent` function was using the `language` property from the Gist API directly in a class name without escaping. A malicious gist with a crafted language name could execute arbitrary JavaScript.
+**Learning:** Even data that seems "safe" like a programming language name must be treated as untrusted input if it comes from an external API and is injected into the DOM.
+**Prevention:** Always escape any value before using it in HTML attributes or class names, even if it's expected to be a simple string.

--- a/src/components/gist-detail.ts
+++ b/src/components/gist-detail.ts
@@ -33,7 +33,7 @@ function getLanguageClass(language?: string): string {
  */
 function renderFileContent(content: string, language?: string): string {
   const lines = content.split('\n');
-  const langClass = getLanguageClass(language);
+  const langClass = esc(getLanguageClass(language));
 
   const linesHtml = lines
     .map((line, i) => {

--- a/src/services/security/logger.ts
+++ b/src/services/security/logger.ts
@@ -39,19 +39,69 @@ export function redactSecrets(input: string): string {
 }
 
 /**
+ * Recursively redact secrets in any value.
+ * Handles strings, Errors, arrays, and nested objects.
+ * Implements cycle detection and depth limiting.
+ */
+export function redactAny(arg: unknown, depth = 0, seen = new WeakSet()): unknown {
+  // Bounded recursion
+  if (depth > 10) return '[DEPTH_EXCEEDED]';
+
+  if (typeof arg === 'string') {
+    return redactSecrets(arg);
+  }
+
+  if (arg instanceof Error) {
+    // Preserve error prototype and custom properties while redacting messages
+    const redactedMessage = redactSecrets(arg.message);
+    const redactedStack = arg.stack ? redactSecrets(arg.stack) : undefined;
+
+    // Create a proxy-like object or a shallow copy that redacts key properties
+    const redactedError = Object.create(Object.getPrototypeOf(arg));
+    Object.getOwnPropertyNames(arg).forEach((prop) => {
+      const val = (arg as unknown as Record<string, unknown>)[prop];
+      if (prop === 'message') {
+        redactedError.message = redactedMessage;
+      } else if (prop === 'stack') {
+        redactedError.stack = redactedStack;
+      } else {
+        redactedError[prop] = redactAny(val, depth + 1, seen);
+      }
+    });
+    return redactedError;
+  }
+
+  if (arg !== null && typeof arg === 'object') {
+    if (seen.has(arg)) return '[CIRCULAR]';
+    seen.add(arg);
+
+    if (Array.isArray(arg)) {
+      return arg.map((item) => redactAny(item, depth + 1, seen));
+    }
+
+    // Avoid redacting complex objects that aren't plain data
+    const proto = Object.getPrototypeOf(arg);
+    if (proto !== null && proto !== Object.prototype) {
+      return arg;
+    }
+
+    const redactedObj: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(arg)) {
+      redactedObj[key] = redactAny(value, depth + 1, seen);
+    }
+    return redactedObj;
+  }
+
+  return arg;
+}
+
+/**
  * Safe console.log that redacts secrets.
  * Use instead of console.log for any output that might contain tokens.
  */
 export function safeLog(...args: unknown[]): void {
-  const redacted = args.map((arg) => {
-    if (typeof arg === 'string') {
-      return redactSecrets(arg);
-    }
-    if (arg instanceof Error) {
-      return new Error(redactSecrets(arg.message));
-    }
-    return arg;
-  });
+  const redacted = args.map((arg) => redactAny(arg));
+  // eslint-disable-next-line no-console
   console.log(...redacted);
 }
 
@@ -59,15 +109,7 @@ export function safeLog(...args: unknown[]): void {
  * Safe console.error that redacts secrets.
  */
 export function safeError(...args: unknown[]): void {
-  const redacted = args.map((arg) => {
-    if (typeof arg === 'string') {
-      return redactSecrets(arg);
-    }
-    if (arg instanceof Error) {
-      return new Error(redactSecrets(arg.message));
-    }
-    return arg;
-  });
+  const redacted = args.map((arg) => redactAny(arg));
   console.error(...redacted);
 }
 
@@ -75,14 +117,6 @@ export function safeError(...args: unknown[]): void {
  * Safe console.warn that redacts secrets.
  */
 export function safeWarn(...args: unknown[]): void {
-  const redacted = args.map((arg) => {
-    if (typeof arg === 'string') {
-      return redactSecrets(arg);
-    }
-    if (arg instanceof Error) {
-      return new Error(redactSecrets(arg.message));
-    }
-    return arg;
-  });
+  const redacted = args.map((arg) => redactAny(arg));
   console.warn(...redacted);
 }


### PR DESCRIPTION
This PR addresses two security issues:
1. **Logging Redaction**: The existing logging utilities only redacted top-level strings. I implemented `redactAny` which recursively scans objects and arrays for GitHub PATs and other secrets, ensuring no accidental leaks in structured logs. It includes cycle detection using a WeakSet and a recursion depth limit.
2. **XSS in Gist Detail**: The programming language name from the GitHub API was being injected directly into a CSS class in `gist-detail.ts` without escaping. I added HTML escaping to this value.

Verification:
- Added a test script (run locally) to confirm nested redaction, cycle handling, and Error property preservation.
- Ran `./scripts/quality_gate.sh` and `npm run check` to ensure no regressions and compliance with repo standards.
- Updated `.jules/sentinel.md` with these findings.

---
*PR created automatically by Jules for task [11598914026674643541](https://jules.google.com/task/11598914026674643541) started by @d-o-hub*