### PR TITLE
Wire Fork Gist UI to Existing API

### DIFF
--- a/src/components/app.ts
+++ b/src/components/app.ts
@@ -290,7 +290,8 @@ export class App {
           container as HTMLElement,
           () => this.navigate('home'),
           (_id) => {},
-          (_id, _v) => {}
+          (_id, _v) => {},
+          (newId) => this.navigateToDetail(newId)
         );
       }
     });

--- a/src/components/gist-card.ts
+++ b/src/components/gist-card.ts
@@ -49,6 +49,7 @@ export function renderCard(gist: GistRecord): string {
 
   const html = `
     <article class="glass-card gist-card" data-gist-id="${esc(gist.id)}" tabindex="0" role="button"
+             data-testid="gist-item"
              aria-label="Open gist: ${esc(description)}">
       <div class="gist-card-header">
         <div class="gist-card-meta">

--- a/src/components/gist-detail.ts
+++ b/src/components/gist-detail.ts
@@ -184,8 +184,11 @@ export function bindDetailEvents(
       const revisions = await GitHub.listGistRevisions(gistId);
       container.innerHTML = renderRevisions(gistId, revisions);
       bindRevisionEvents(container, {
-        onBack: () =>
-          void loadGistDetail(gistId, container, onBack, onEdit, onViewRevision, onForkSuccess),
+        onBack: () => {
+          loadGistDetail(gistId, container, onBack, onEdit, onViewRevision, onForkSuccess).catch(
+            (err) => safeError('[GistDetail] onBack failed', err)
+          );
+        },
         onViewRevision,
       });
     } catch {
@@ -214,7 +217,11 @@ export function bindDetailEvents(
   container.querySelector('[data-action="star"]')?.addEventListener('click', async () => {
     if (!gistId) return;
     const ok = await gistStore.toggleStar(gistId);
-    if (ok) void loadGistDetail(gistId, container, onBack, onEdit, onViewRevision, onForkSuccess);
+    if (ok) {
+      loadGistDetail(gistId, container, onBack, onEdit, onViewRevision, onForkSuccess).catch(
+        (err) => safeError('[GistDetail] star refresh failed', err)
+      );
+    }
   });
 }
 

--- a/src/components/gist-detail.ts
+++ b/src/components/gist-detail.ts
@@ -8,6 +8,8 @@ import { GistRevision } from '../types/api';
 import * as GitHub from '../services/github/client';
 import { toast } from './ui/toast';
 import { safeError } from '../services/security/logger';
+import { showConfirmDialog } from '../utils/dialog';
+import gistStore from '../stores/gist-store';
 
 function formatRelativeTime(dateStr: string): string {
   const now = new Date();
@@ -116,12 +118,13 @@ export async function loadGistDetail(
   container: HTMLElement,
   onBack: () => void,
   onEdit: (id: string) => void,
-  onViewRevision: (id: string, version: string) => void
+  onViewRevision: (id: string, version: string) => void,
+  onForkSuccess: (id: string) => void
 ): Promise<void> {
   try {
     const gist = await GitHub.getGist(id);
     container.innerHTML = renderGistDetail(gist as unknown as GistRecord);
-    bindDetailEvents(container, { onBack, onEdit, onViewRevision });
+    bindDetailEvents(container, { onBack, onEdit, onViewRevision, onForkSuccess });
   } catch (err) {
     safeError('[GistDetail] Failed to load gist', err);
     toast.error('FAILED TO LOAD GIST DETAILS');
@@ -161,10 +164,12 @@ export function bindDetailEvents(
     onBack,
     onEdit,
     onViewRevision,
+    onForkSuccess,
   }: {
     onBack: () => void;
     onEdit: (id: string) => void;
     onViewRevision: (id: string, version: string) => void;
+    onForkSuccess: (id: string) => void;
   }
 ): void {
   const gistId = container.querySelector('.gist-detail')?.getAttribute('data-gist-id');
@@ -179,7 +184,8 @@ export function bindDetailEvents(
       const revisions = await GitHub.listGistRevisions(gistId);
       container.innerHTML = renderRevisions(gistId, revisions);
       bindRevisionEvents(container, {
-        onBack: () => loadGistDetail(gistId, container, onBack, onEdit, onViewRevision),
+        onBack: () =>
+          void loadGistDetail(gistId, container, onBack, onEdit, onViewRevision, onForkSuccess),
         onViewRevision,
       });
     } catch {
@@ -187,11 +193,28 @@ export function bindDetailEvents(
     }
   });
 
+  // Fork button
+  container.querySelector('[data-action="fork"]')?.addEventListener('click', async () => {
+    if (!gistId) return;
+    const confirmed = await showConfirmDialog('FORK THIS GIST?');
+    if (!confirmed) return;
+
+    try {
+      const forked = await GitHub.forkGist(gistId);
+      await gistStore.addGist(forked);
+      toast.success('GIST FORKED');
+      onForkSuccess(forked.id);
+    } catch (err) {
+      safeError('[GistDetail] Fork failed', err);
+      toast.error('FAILED TO FORK GIST');
+    }
+  });
+
   // Star button
   container.querySelector('[data-action="star"]')?.addEventListener('click', async () => {
     if (!gistId) return;
-    const ok = await (await import('../stores/gist-store')).default.toggleStar(gistId);
-    if (ok) loadGistDetail(gistId, container, onBack, onEdit, onViewRevision);
+    const ok = await gistStore.toggleStar(gistId);
+    if (ok) void loadGistDetail(gistId, container, onBack, onEdit, onViewRevision, onForkSuccess);
   });
 }
 

--- a/src/stores/gist-store.ts
+++ b/src/stores/gist-store.ts
@@ -221,6 +221,16 @@ class GistStore {
     }
   }
 
+  /**
+   * Add a new gist to the store (e.g. after forking or external creation)
+   */
+  async addGist(gist: GitHubGist): Promise<void> {
+    const record = this.githubGistToRecord(gist);
+    await dbSaveGist(record);
+    this.mergeGistRecord(record, false);
+    this.notifyListeners();
+  }
+
   private githubGistToRecord(gist: GitHubGist, starred = false): GistRecord {
     return {
       id: gist.id,


### PR DESCRIPTION
The fork button in the gist detail view has been connected to the GitHub API. 

Key changes:
- `GistStore.addGist`: New method to handle adding a single Gist (from API) to local IndexedDB and in-memory state.
- `GistDetail`: 
    - Added click handler for the fork button.
    - Integrated `showConfirmDialog` for user confirmation.
    - Added `onForkSuccess` callback to handle post-fork navigation.
    - Refactored `gistStore` import to be static for better type safety and consistency.
- `App`: Updated `navigateToDetail` to pass the new `onForkSuccess` callback, ensuring a smooth transition to the newly created fork.
- `GistCard`: Added `data-testid="gist-item"` to ensure consistent element selection in automated tests.

All changes have been verified against the project's quality gates (type-checking, linting, and formatting).

Fixes #25

---
*PR created automatically by Jules for task [670535198125592189](https://jules.google.com/task/670535198125592189) started by @d-o-hub*