### PR TITLE
feat: enforce strict unused vars and catch blocks

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -46,7 +46,8 @@ export default tseslint.config(
     rules: {
       // TypeScript strict rules
       '@typescript-eslint/no-explicit-any': 'error',
-      '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+      '@typescript-eslint/no-unused-vars': ['error', { caughtErrors: 'all' }],
+      'no-unused-vars': 'off',
       '@typescript-eslint/explicit-function-return-type': ['warn', { allowExpressions: true }],
 
       // Promise handling - warn for existing codebase, error for new code

--- a/plans/strict-unused-vars.md
+++ b/plans/strict-unused-vars.md
@@ -1,0 +1,23 @@
+# Plan: Enforce Strict Unused Variables Rule
+
+## Objective
+Update `eslint.config.js` to strictly enforce the `@typescript-eslint/no-unused-vars` rule by removing ignore patterns and setting `"caughtErrors": "all"`. Resolve all resulting lint errors across the codebase.
+
+## Steps
+
+### 1. Update ESLint Configuration
+Modify `eslint.config.js`:
+- Change `@typescript-eslint/no-unused-vars` to:
+  `['error', { 'caughtErrors': 'all' }]`
+- Remove `{ argsIgnorePattern: '^_' }` or any similar ignores.
+
+### 2. Fix Unused Catch Bindings
+- Search for `catch (e)` or `catch (err)` where the error variable is unused.
+- Replace with optional catch bindings: `catch {`.
+
+### 3. Fix Other Unused Variables
+- Run `pnpm check`.
+- Fix any new linting errors related to unused variables (e.g., unused parameters, unused imports).
+
+### 4. Verify
+- Ensure `pnpm check` passes with zero linting errors.


### PR DESCRIPTION
- Enforces `caughtErrors: 'all'` in `eslint.config.js`
- Turns off the base `no-unused-vars` to prevent duplication with `@typescript-eslint/no-unused-vars`
- Pre-emptively verified no unused bindings remained in source code
- Created plan detailing the process

---
*PR created automatically by Jules for task [7229882934831093227](https://jules.google.com/task/7229882934831093227) started by @d-o-hub*