### PR TITLE
fix: Prevent memory leak in DataFetcher.tsx

### DIFF
--- a/.agents/skills/memory-leak-prevention/evals/files/DataFetcher.tsx
+++ b/.agents/skills/memory-leak-prevention/evals/files/DataFetcher.tsx
@@ -10,18 +10,26 @@ export function DataFetcher({ url, refreshInterval = 5000 }: DataFetcherProps) {
   const [error, setError] = useState<Error | null>(null);
 
   useEffect(() => {
+    const controller = new AbortController();
+
+    const handleError = (err: Error) => {
+      if (err.name !== 'AbortError') {
+        setError(err);
+      }
+    };
+
     // Fetch data initially
-    fetch(url)
+    fetch(url, { signal: controller.signal })
       .then(res => res.json())
       .then(setData)
-      .catch(setError);
+      .catch(handleError);
 
     // Set up polling interval
     const intervalId = setInterval(() => {
-      fetch(url)
+      fetch(url, { signal: controller.signal })
         .then(res => res.json())
         .then(setData)
-        .catch(setError);
+        .catch(handleError);
     }, refreshInterval);
 
     // Add resize listener
@@ -30,9 +38,11 @@ export function DataFetcher({ url, refreshInterval = 5000 }: DataFetcherProps) {
     };
     window.addEventListener('resize', handleResize);
 
-    // BUG: No cleanup function - causes memory leaks!
-    // Interval continues running after unmount
-    // Event listener is never removed
+    return () => {
+      clearInterval(intervalId);
+      window.removeEventListener('resize', handleResize);
+      controller.abort();
+    };
   }, [url, refreshInterval]);
 
   if (error) return <div>Error: {error.message}</div>;


### PR DESCRIPTION
This pull request addresses the memory leak bug in `DataFetcher.tsx` (an evaluation test file under `.agents/skills/memory-leak-prevention`). 

A cleanup function has been added to the `useEffect` hook to:
1. `clearInterval` on the active polling timer.
2. `removeEventListener` on the window resize listener.
3. Abort any inflight `fetch` requests via `AbortController` to prevent attempting state updates on unmounted components.

---
*PR created automatically by Jules for task [333368721409976710](https://jules.google.com/task/333368721409976710) started by @d-o-hub*