### PR TITLE
🧹 [Code Health] Refactor renderConflictDetail to use helper functions

### DIFF
--- a/src/components/conflict-resolution.ts
+++ b/src/components/conflict-resolution.ts
@@ -51,6 +51,61 @@ export function renderConflictList(conflicts: GistConflict[]): string {
   `;
 }
 
+interface VersionData {
+  description: string | null;
+  public: boolean;
+  files: Record<string, { size?: number }>;
+}
+
+function renderFiles(files: Record<string, { size?: number }>): string {
+  return Object.entries(files)
+    .map(
+      ([name, file]) => `
+                  <div class="comp-file-item">
+                    <span class="file-name">${sanitizeHtml(name)}</span>
+                    <span class="file-size">${file.size || 0} bytes</span>
+                  </div>
+                `
+    )
+    .join('');
+}
+
+function renderComparisonColumn(
+  colClass: string,
+  title: string,
+  subtitle: string,
+  version: VersionData,
+  conflictingFields: string[],
+  btnClass: string,
+  strategy: string,
+  btnText: string
+): string {
+  return `
+        <div class="comparison-col ${colClass}">
+          <div class="comparison-header">
+            <h2 class="comparison-title">${title}</h2>
+            <span class="micro-label">${subtitle}</span>
+          </div>
+          <div class="comparison-body">
+            <div class="comp-field ${conflictingFields.includes('description') ? 'has-conflict' : ''}">
+              <label class="micro-label">DESCRIPTION</label>
+              <div class="comp-value">${version.description ? sanitizeHtml(version.description) : '<i>No description</i>'}</div>
+            </div>
+            <div class="comp-field ${conflictingFields.includes('public') ? 'has-conflict' : ''}">
+              <label class="micro-label">VISIBILITY</label>
+              <div class="comp-value">${version.public ? 'PUBLIC' : 'SECRET'}</div>
+            </div>
+            <div class="comp-field ${conflictingFields.includes('content') ? 'has-conflict' : ''}">
+              <label class="micro-label">FILES</label>
+              <div class="comp-files">
+                ${renderFiles(version.files)}
+              </div>
+            </div>
+          </div>
+          <button class="btn ${btnClass} resolve-choice-btn" data-strategy="${strategy}">${btnText}</button>
+        </div>`;
+}
+
 /**
  * Render detailed side-by-side comparison for a single conflict.
  */
@@ -67,72 +122,28 @@ export function renderConflictDetail(conflict: GistConflict): string {
 
       <div class="comparison-grid">
         <!-- Local Version -->
-        <div class="comparison-col local-version">
-          <div class="comparison-header">
-            <h2 class="comparison-title">LOCAL VERSION</h2>
-            <span class="micro-label">YOUR CHANGES</span>
-          </div>
-          <div class="comparison-body">
-            <div class="comp-field ${conflictingFields.includes('description') ? 'has-conflict' : ''}">
-              <label class="micro-label">DESCRIPTION</label>
-              <div class="comp-value">${local.description ? sanitizeHtml(local.description) : '<i>No description</i>'}</div>
-            </div>
-            <div class="comp-field ${conflictingFields.includes('public') ? 'has-conflict' : ''}">
-              <label class="micro-label">VISIBILITY</label>
-              <div class="comp-value">${local.public ? 'PUBLIC' : 'SECRET'}</div>
-            </div>
-            <div class="comp-field ${conflictingFields.includes('content') ? 'has-conflict' : ''}">
-              <label class="micro-label">FILES</label>
-              <div class="comp-files">
-                ${Object.entries(local.files)
-                  .map(
-                    ([name, file]) => `
-                  <div class="comp-file-item">
-                    <span class="file-name">${sanitizeHtml(name)}</span>
-                    <span class="file-size">${file.size || 0} bytes</span>
-                  </div>
-                `
-                  )
-                  .join('')}
-              </div>
-            </div>
-          </div>
-          <button class="btn btn-primary resolve-choice-btn" data-strategy="local-wins">KEEP LOCAL VERSION</button>
-        </div>
+        ${renderComparisonColumn(
+          'local-version',
+          'LOCAL VERSION',
+          'YOUR CHANGES',
+          local,
+          conflictingFields,
+          'btn-primary',
+          'local-wins',
+          'KEEP LOCAL VERSION'
+        )}
 
         <!-- Remote Version -->
-        <div class="comparison-col remote-version">
-          <div class="comparison-header">
-            <h2 class="comparison-title">REMOTE VERSION</h2>
-            <span class="micro-label">GITHUB CHANGES</span>
-          </div>
-          <div class="comparison-body">
-            <div class="comp-field ${conflictingFields.includes('description') ? 'has-conflict' : ''}">
-              <label class="micro-label">DESCRIPTION</label>
-              <div class="comp-value">${remote.description ? sanitizeHtml(remote.description) : '<i>No description</i>'}</div>
-            </div>
-            <div class="comp-field ${conflictingFields.includes('public') ? 'has-conflict' : ''}">
-              <label class="micro-label">VISIBILITY</label>
-              <div class="comp-value">${remote.public ? 'PUBLIC' : 'SECRET'}</div>
-            </div>
-            <div class="comp-field ${conflictingFields.includes('content') ? 'has-conflict' : ''}">
-              <label class="micro-label">FILES</label>
-              <div class="comp-files">
-                ${Object.entries(remote.files)
-                  .map(
-                    ([name, file]) => `
-                  <div class="comp-file-item">
-                    <span class="file-name">${sanitizeHtml(name)}</span>
-                    <span class="file-size">${file.size || 0} bytes</span>
-                  </div>
-                `
-                  )
-                  .join('')}
-              </div>
-            </div>
-          </div>
-          <button class="btn btn-ghost resolve-choice-btn" data-strategy="remote-wins">USE REMOTE VERSION</button>
-        </div>
+        ${renderComparisonColumn(
+          'remote-version',
+          'REMOTE VERSION',
+          'GITHUB CHANGES',
+          remote,
+          conflictingFields,
+          'btn-ghost',
+          'remote-wins',
+          'USE REMOTE VERSION'
+        )}
       </div>
     </div>
   `;


### PR DESCRIPTION
🎯 **What:** 
Refactored the `renderConflictDetail` function in `src/components/conflict-resolution.ts` by extracting duplicated template string logic into `renderComparisonColumn` and `renderFiles` helper functions. Also introduced a `VersionData` interface to strongly type the data passed to these functions.

💡 **Why:**
The previous implementation of `renderConflictDetail` was quite long and featured completely duplicated logic for both the 'Local Version' and 'Remote Version' columns. Extracting these chunks into smaller render functions is a low-risk, high-reward change that significantly improves maintainability, readability, and DRYs up the component logic.

✅ **Verification:**
- Ran `npm run check` to verify formatting, linting, and type definitions.
- Ran `npm run quality` to ensure all quality gates (including benchmark and playwright tests) passed cleanly.
- Visual inspection of the generated diff confirms the code behavior remains strictly unchanged while the underlying duplication has been cleanly eliminated.

✨ **Result:**
A cleaner, more modular, and safer conflict resolution component layout logic.

---
*PR created automatically by Jules for task [13657133370626550166](https://jules.google.com/task/13657133370626550166) started by @d-o-hub*