### PR TITLE
fix: prevent memory leak in WebSocketComponent

### DIFF
--- a/.agents/skills/memory-leak-prevention/evals/files/WebSocketComponent.vue
+++ b/.agents/skills/memory-leak-prevention/evals/files/WebSocketComponent.vue
@@ -9,13 +9,14 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted } from 'vue';
-import { Subject } from 'rxjs';
+import { ref, onMounted, onUnmounted } from 'vue';
+import { Subject, Subscription } from 'rxjs';
 
 const connected = ref(false);
 const messages = ref<any[]>([]);
 
 let ws: WebSocket | null = null;
+let subscription: Subscription | null = null;
 const messageSubject$ = new Subject<any>();
 
 onMounted(() => {
@@ -36,12 +37,19 @@ onMounted(() => {
   };
   
   // Subscribe to RxJS observable
-  messageSubject$.subscribe((msg) => {
+  subscription = messageSubject$.subscribe((msg) => {
     messages.value.push(msg);
   });
-  
-  // BUG: No cleanup on unmount!
-  // WebSocket connection stays open
-  // Observable subscription is never unsubscribed
+});
+
+onUnmounted(() => {
+  if (ws) {
+    ws.close();
+    ws = null;
+  }
+  if (subscription) {
+    subscription.unsubscribe();
+    subscription = null;
+  }
 });
 </script>


### PR DESCRIPTION
This PR addresses the issue described in `.agents/skills/memory-leak-prevention/evals/files/WebSocketComponent.vue:43`.
The component was previously establishing a WebSocket connection and an RxJS observable subscription upon mounting, but failed to clean them up when the component unmounted, leading to memory leaks.

This fix:
1. Imports `onUnmounted` from Vue.
2. Captures the RxJS subscription object.
3. Implements the `onUnmounted` hook to close the WebSocket connection (`ws.close()`) and clean up the subscription (`subscription.unsubscribe()`).

---
*PR created automatically by Jules for task [5135606403827177319](https://jules.google.com/task/5135606403827177319) started by @d-o-hub*