### PR TITLE
🔒 [security fix] Insufficient HTML Sanitization via DOM innerHTML Assignment

### DIFF
--- a/src/components/app.ts
+++ b/src/components/app.ts
@@ -9,6 +9,7 @@ import { commandPalette } from './ui/command-palette';
 import { bottomSheet } from './ui/bottom-sheet';
 import { withViewTransition } from '../utils/view-transitions';
 import { announcer } from '../utils/announcer';
+import { sanitizeHtml } from '../services/security/dom';
 import * as offlineRoute from '../routes/offline';
 import * as createRoute from '../routes/create';
 
@@ -92,7 +93,7 @@ export class App {
 
   private async navigate(route: Route): Promise<void> {
     this.currentRoute = route;
-    announcer.announce(`Navigating to ${route} page`);
+    announcer.announce(`Navigating to ${sanitizeHtml(route)} page`);
 
     const savedSort = localStorage.getItem('sort-preference') || 'updated-desc';
 
@@ -263,7 +264,7 @@ export class App {
     const status = online ? (len > 0 ? 'syncing' : 'online') : 'offline';
     if (el) {
       el.setAttribute('data-status', status);
-      el.innerHTML = `<span class="sync-dot" aria-hidden="true"></span><span class="sr-only">${status}</span>`;
+      el.innerHTML = `<span class="sync-dot" aria-hidden="true"></span><span class="sr-only">${sanitizeHtml(status)}</span>`;
     }
   }
 

--- a/src/components/conflict-resolution.ts
+++ b/src/components/conflict-resolution.ts
@@ -33,10 +33,10 @@ export function renderConflictList(conflicts: GistConflict[]): string {
       ${conflicts
         .map(
           (c) => `
-        <div class="glass-card conflict-item" data-id="${c.gistId}">
+        <div class="glass-card conflict-item" data-id="${sanitizeHtml(c.gistId)}">
           <div class="conflict-item-header">
             <h3 class="conflict-item-title">${sanitizeHtml(c.localVersion.description || 'UNTITLED GIST')}</h3>
-            <span class="micro-label">ID: ${c.gistId.substring(0, 8)}</span>
+            <span class="micro-label">ID: ${sanitizeHtml(c.gistId.substring(0, 8))}</span>
           </div>
           <div class="conflict-item-meta">
             <span class="detail-chip">CONFLICTING: ${c.conflictingFields.map(sanitizeHtml).join(', ')}</span>
@@ -62,7 +62,7 @@ export function renderConflictDetail(conflict: GistConflict): string {
       <header class="detail-header">
         <button class="btn btn-ghost back-to-list">← BACK TO LIST</button>
         <h1 class="detail-title">RESOLVE CONFLICT</h1>
-        <p class="micro-label">GIST ID: ${conflict.gistId}</p>
+        <p class="micro-label">GIST ID: ${sanitizeHtml(conflict.gistId)}</p>
       </header>
 
       <div class="comparison-grid">

--- a/src/components/gist-card.ts
+++ b/src/components/gist-card.ts
@@ -7,6 +7,7 @@ import type { GistRecord } from '../services/db';
 import gistStore from '../stores/gist-store';
 import { toast } from './ui/toast';
 import { showConfirmDialog } from '../utils/dialog';
+import { sanitizeHtml } from '../services/security/dom';
 
 function formatRelativeTime(dateStr: string): string {
   const now = new Date();
@@ -20,16 +21,6 @@ function formatRelativeTime(dateStr: string): string {
   if (diffHr < 24) return `${diffHr}H AGO`;
   const diffDay = Math.floor(diffHr / 24);
   return `${diffDay}D AGO`;
-}
-
-function esc(text: string): string {
-  if (!text) return '';
-  return String(text)
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#039;');
 }
 
 const cardCache = new Map<string, { html: string; updatedAt: string }>();
@@ -48,12 +39,12 @@ export function renderCard(gist: GistRecord): string {
   const snippet = content.slice(0, 120);
 
   const html = `
-    <article class="glass-card gist-card" data-gist-id="${esc(gist.id)}" data-testid="gist-item" tabindex="0" role="button"
-             aria-label="Open gist: ${esc(description)}">
+    <article class="glass-card gist-card" data-gist-id="${sanitizeHtml(gist.id)}" data-testid="gist-item" tabindex="0" role="button"
+             aria-label="Open gist: ${sanitizeHtml(description)}">
       <div class="gist-card-header">
         <div class="gist-card-meta">
-          <span class="micro-label">${esc(language.toUpperCase())}</span>
-          <h2 class="gist-card-title">${esc(description)}</h2>
+          <span class="micro-label">${sanitizeHtml(language.toUpperCase())}</span>
+          <h2 class="gist-card-title">${sanitizeHtml(description)}</h2>
         </div>
         <div class="gist-card-stat">
           <span class="stat-number">${fileCount}</span>
@@ -61,17 +52,17 @@ export function renderCard(gist: GistRecord): string {
         </div>
       </div>
       <div class="gist-card-preview">
-        <pre class="gist-preview-code"><code>${esc(snippet)}</code></pre>
+        <pre class="gist-preview-code"><code>${sanitizeHtml(snippet)}</code></pre>
       </div>
       <footer class="gist-card-actions">
         <div class="action-group">
-          <button class="gist-action-btn star-btn" data-id="${esc(gist.id)}"
+          <button class="gist-action-btn star-btn" data-id="${sanitizeHtml(gist.id)}"
                   aria-label="${gist.starred ? 'Unstar' : 'Star'} gist"
                   aria-pressed="${gist.starred}">
             ${gist.starred ? '★' : '☆'}
             <span class="micro-label">${gist.starred ? 'STARRED' : 'STAR'}</span>
           </button>
-          <button class="gist-action-btn delete-btn" data-id="${esc(gist.id)}" aria-label="Delete gist">
+          <button class="gist-action-btn delete-btn" data-id="${sanitizeHtml(gist.id)}" aria-label="Delete gist">
             <span class="micro-label">DELETE</span>
           </button>
         </div>

--- a/src/components/gist-detail.ts
+++ b/src/components/gist-detail.ts
@@ -8,6 +8,7 @@ import { GistRevision } from '../types/api';
 import * as GitHub from '../services/github/client';
 import { toast } from './ui/toast';
 import { safeError } from '../services/security/logger';
+import { sanitizeHtml } from '../services/security/dom';
 
 function formatRelativeTime(dateStr: string): string {
   const now = new Date();
@@ -23,18 +24,8 @@ function formatRelativeTime(dateStr: string): string {
   return `${diffDay}d ago`;
 }
 
-const esc = (text: string): string => {
-  if (!text) return '';
-  return text
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#039;');
-};
-
 export function renderFileContent(content: string, language?: string): string {
-  return `<pre class="code-block language-${esc(language || 'text')}"><code>${esc(content)}</code></pre>`;
+  return `<pre class="code-block language-${sanitizeHtml(language || 'text')}"><code>${sanitizeHtml(content)}</code></pre>`;
 }
 
 export function renderGistDetail(gist: GistRecord): string {
@@ -51,8 +42,8 @@ export function renderGistDetail(gist: GistRecord): string {
       ${Object.entries(gist.files)
         .map(
           ([key, file], index) => `
-        <button class="chip file-tab ${index === 0 ? 'active' : ''}" data-file-key="${esc(key)}" id="tab-${index}" role="tab" aria-selected="${index === 0}" aria-controls="file-content-area">
-          ${esc(file.filename.toUpperCase())}
+        <button class="chip file-tab ${index === 0 ? 'active' : ''}" data-file-key="${sanitizeHtml(key)}" id="tab-${index}" role="tab" aria-selected="${index === 0}" aria-controls="file-content-area">
+          ${sanitizeHtml(file.filename.toUpperCase())}
         </button>
       `
         )
@@ -67,13 +58,13 @@ export function renderGistDetail(gist: GistRecord): string {
     : '<p class="empty-content">No content available</p>';
 
   return `
-    <div class="gist-detail" data-gist-id="${esc(gist.id)}">
+    <div class="gist-detail" data-gist-id="${sanitizeHtml(gist.id)}">
       <header class="detail-header">
         <div class="header-top">
           <button class="btn btn-ghost" id="gist-back-btn" aria-label="Go back">← Back</button>
           <span class="micro-label">Gist Detail</span>
         </div>
-        <h1 class="detail-title">${esc(title)}</h1>
+        <h1 class="detail-title">${sanitizeHtml(title)}</h1>
         <div class="detail-meta-row">
           <span class="detail-chip">${fileCount} Files</span>
           <span class="detail-chip">${visibility}</span>
@@ -101,8 +92,8 @@ export function renderGistDetail(gist: GistRecord): string {
         ${
           firstFile
             ? `
-          <span class="micro-label">Language: ${esc(firstFile.language || 'Unknown')}</span>
-          <span class="micro-label">Raw URL: <a href="${esc(firstFile.rawUrl || '')}" target="_blank" rel="noopener noreferrer">Link</a></span>
+          <span class="micro-label">Language: ${sanitizeHtml(firstFile.language || 'Unknown')}</span>
+          <span class="micro-label">Raw URL: <a href="${sanitizeHtml(firstFile.rawUrl || '')}" target="_blank" rel="noopener noreferrer">Link</a></span>
         `
             : ''
         }
@@ -133,19 +124,19 @@ export function renderRevisions(gistId: string, revisions: GistRevision[]): stri
     .map((rev) => {
       const date = new Date(rev.committed_at).toLocaleString();
       return `
-      <div class="revision-item glass-card" data-version="${esc(rev.version)}">
+      <div class="revision-item glass-card" data-version="${sanitizeHtml(rev.version)}">
         <div class="revision-meta">
           <span class="stat-number">${date}</span>
-          <span class="micro-label">By ${esc(rev.user?.login || 'Unknown')}</span>
+          <span class="micro-label">By ${sanitizeHtml(rev.user?.login || 'Unknown')}</span>
         </div>
-        <button class="btn btn-ghost btn-sm" data-action="view-revision" data-version="${esc(rev.version)}">View</button>
+        <button class="btn btn-ghost btn-sm" data-action="view-revision" data-version="${sanitizeHtml(rev.version)}">View</button>
       </div>
     `;
     })
     .join('');
 
   return `
-    <div class="revisions-list" data-gist-id="${esc(gistId)}">
+    <div class="revisions-list" data-gist-id="${sanitizeHtml(gistId)}">
       <header class="detail-header">
         <button class="btn btn-ghost" id="gist-back-btn">← Back</button>
         <h1 class="detail-title">Revisions (${revisions.length})</h1>

--- a/src/components/gist-edit.ts
+++ b/src/components/gist-edit.ts
@@ -7,33 +7,24 @@ import type { GistRecord } from '../services/db';
 import { getGist } from '../services/db';
 import gistStore from '../stores/gist-store';
 import { toast } from './ui/toast';
+import { sanitizeHtml } from '../services/security/dom';
 // import { customConfirm } from './app';
-
-const esc = (text: string): string => {
-  if (!text) return '';
-  return text
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#039;');
-};
 
 export function renderEditForm(gist: GistRecord): string {
   const filesHtml = Object.entries(gist.files)
     .map(
       ([key, file]) => `
-    <div class="file-editor glass-card" data-file-key="${esc(key)}" style="padding: var(--space-4); margin-bottom: var(--space-4);">
+    <div class="file-editor glass-card" data-file-key="${sanitizeHtml(key)}" style="padding: var(--space-4); margin-bottom: var(--space-4);">
       <div class="form-group">
         <label class="form-label">FILENAME</label>
         <div style="display: flex; gap: var(--space-2);">
-            <input type="text" class="form-input filename-input" value="${esc(file.filename)}" placeholder="example.js" />
+            <input type="text" class="form-input filename-input" value="${sanitizeHtml(file.filename)}" placeholder="example.js" />
             <button type="button" class="btn btn-danger remove-file-btn" ${Object.keys(gist.files).length <= 1 ? 'style="display: none;"' : ''}>×</button>
         </div>
       </div>
       <div class="form-group">
         <label class="form-label">CONTENT</label>
-        <textarea class="form-textarea content-editor" placeholder="Enter content...">${esc(file.content || '')}</textarea>
+        <textarea class="form-textarea content-editor" placeholder="Enter content...">${sanitizeHtml(file.content || '')}</textarea>
       </div>
     </div>
   `
@@ -41,7 +32,7 @@ export function renderEditForm(gist: GistRecord): string {
     .join('');
 
   return `
-    <div class="route-edit" data-gist-id="${esc(gist.id)}">
+    <div class="route-edit" data-gist-id="${sanitizeHtml(gist.id)}">
       <header class="detail-header">
         <button class="btn btn-ghost" id="edit-back-btn">← BACK</button>
         <h1 class="detail-title">EDIT GIST</h1>
@@ -50,7 +41,7 @@ export function renderEditForm(gist: GistRecord): string {
       <form id="edit-gist-form" class="gist-form" style="padding: var(--space-6);">
         <div class="form-group">
           <label class="form-label">DESCRIPTION</label>
-          <input type="text" id="edit-description" name="description" class="form-input" value="${esc(gist.description || '')}" />
+          <input type="text" id="edit-description" name="description" class="form-input" value="${sanitizeHtml(gist.description || '')}" />
         </div>
 
         <div class="files-section" id="edit-files-section">

--- a/src/components/ui/bottom-sheet.ts
+++ b/src/components/ui/bottom-sheet.ts
@@ -6,6 +6,7 @@
 import { focusTrap } from '../../utils/focus-trap';
 import { announcer } from '../../utils/announcer';
 import { withViewTransition } from '../../utils/view-transitions';
+import { sanitizeHtml } from '../../services/security/dom';
 
 export class BottomSheet {
   private container: HTMLElement | null = null;
@@ -44,7 +45,7 @@ export class BottomSheet {
     this.isOpen = true;
 
     // Set content
-    const header = title ? `<h2 class="bottom-sheet-title">${title}</h2>` : '';
+    const header = title ? `<h2 class="bottom-sheet-title">${sanitizeHtml(title)}</h2>` : '';
     this.container.innerHTML = `
       <div class="bottom-sheet-handle"></div>
       ${header}

--- a/src/routes/offline.ts
+++ b/src/routes/offline.ts
@@ -5,6 +5,7 @@
 import syncQueue from '../services/sync/queue';
 import { EmptyState } from '../components/ui/empty-state';
 import { getConflicts } from '../services/sync/conflict-detector';
+import { sanitizeHtml } from '../services/security/dom';
 
 let syncChangeHandler: (() => void) | undefined;
 
@@ -62,7 +63,7 @@ async function updateOfflineStatus(container: HTMLElement): Promise<void> {
     const content =
       count > 0
         ? `<div class="glass-card" style="padding: var(--space-6); text-align: center;">
-             <p class="micro-label">${count} operation${count !== 1 ? 's' : ''} waiting for connection</p>
+             <p class="micro-label">${sanitizeHtml(String(count))} operation${count !== 1 ? 's' : ''} waiting for connection</p>
            </div>`
         : EmptyState.render({
             title: 'All Synced',

--- a/src/routes/settings.ts
+++ b/src/routes/settings.ts
@@ -97,7 +97,7 @@ async function loadTokenInfo(container: HTMLElement): Promise<void> {
   const token = await getToken();
   if (el) {
     if (token) {
-      el.innerHTML = `<p class="micro-label token-saved">Token active: ${redactToken(token)}</p>`;
+      el.innerHTML = `<p class="micro-label token-saved">Token active: ${sanitizeHtml(redactToken(token))}</p>`;
     } else {
       el.innerHTML = '<p class="micro-label token-missing">No token saved. Add one above.</p>';
     }

--- a/src/utils/dialog.ts
+++ b/src/utils/dialog.ts
@@ -2,6 +2,8 @@
  * Shared dialog utilities — avoids circular imports between components.
  */
 
+import { sanitizeHtml } from '../services/security/dom';
+
 /**
  * Show a modal confirmation dialog. Returns true if the user confirms.
  * Replaces native confirm() for better UX and CSP compliance.
@@ -12,8 +14,8 @@ export function showConfirmDialog(message: string, title = 'CONFIRM'): Promise<b
     overlay.className = 'confirm-overlay';
     overlay.innerHTML = `
       <div class="confirm-dialog glass-card" role="dialog" aria-modal="true">
-        <h2 class="confirm-title">${title}</h2>
-        <p class="confirm-message">${message}</p>
+        <h2 class="confirm-title">${sanitizeHtml(title)}</h2>
+        <p class="confirm-message">${sanitizeHtml(message)}</p>
         <div class="confirm-actions">
           <button class="btn btn-ghost" data-action="cancel">CANCEL</button>
           <button class="btn btn-danger" data-action="confirm">CONFIRM</button>

--- a/tests/unit/security-dom.test.ts
+++ b/tests/unit/security-dom.test.ts
@@ -1,0 +1,18 @@
+import { sanitizeHtml } from '../../src/services/security/dom.ts';
+import assert from 'node:assert';
+import test from 'node:test';
+
+test('sanitizeHtml escapes special characters', () => {
+  const input = '<script>alert("xss")</script> & " \'';
+  const expected = '&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt; &amp; &quot; &#039;';
+  assert.strictEqual(sanitizeHtml(input), expected);
+});
+
+test('sanitizeHtml handles null/undefined', () => {
+  assert.strictEqual(sanitizeHtml(null as any), '');
+  assert.strictEqual(sanitizeHtml(undefined as any), '');
+});
+
+test('sanitizeHtml handles numbers', () => {
+  assert.strictEqual(sanitizeHtml(123 as any), '123');
+});


### PR DESCRIPTION
🎯 **What:** Fixed multiple instances of insufficient HTML sanitization when using `innerHTML` or template strings throughout the application.

⚠️ **Risk:** Potential for Cross-Site Scripting (XSS) attacks. Malicious users could craft gists with script tags in descriptions, filenames, or content that would execute in the context of other users viewing them.

🛡️ **Solution:** 
- Standardized all dynamic HTML injection to use the centralized `sanitizeHtml` utility from `src/services/security/dom.ts`.
- Removed redundant and potentially inconsistent local `esc` functions in core components.
- Hardened UI utilities like `dialog.ts` and `bottom-sheet.ts` which were previously missing sanitization for titles and messages.
- Verified the fix with a new targeted unit test in `tests/unit/security-dom.test.ts` using Node 22's built-in test runner.

---
*PR created automatically by Jules for task [15859524230087063640](https://jules.google.com/task/15859524230087063640) started by @d-o-hub*