### PR TITLE
🎨 Palette: Add Copy to Clipboard feature to Gist Detail

### DIFF
--- a/src/components/gist-detail.ts
+++ b/src/components/gist-detail.ts
@@ -97,16 +97,17 @@ export function renderGistDetail(gist: GistRecord): string {
         ${content}
       </div>
 
-      <div class="file-info" id="file-info">
-        ${
-          firstFile
-            ? `
+      ${
+        firstFile
+          ? `
+        <div class="file-info" id="file-info">
           <span class="micro-label">Language: ${esc(firstFile.language || 'Unknown')}</span>
           <span class="micro-label">Raw URL: <a href="${esc(firstFile.rawUrl || '')}" target="_blank" rel="noopener noreferrer">Link</a></span>
-        `
-            : ''
-        }
-      </div>
+          <button class="btn btn-ghost btn-copy-sm" data-action="copy-content" data-testid="copy-code-btn">📋 Copy</button>
+        </div>
+      `
+          : ''
+      }
     </div>
   `;
 }
@@ -196,6 +197,37 @@ export function bindDetailEvents(
       const ok = await (await import('../stores/gist-store')).default.toggleStar(gistId);
       if (ok) void loadGistDetail(gistId, container, onBack, onEdit, onViewRevision);
     })();
+  });
+
+  // Copy button
+  container.querySelector('[data-action="copy-content"]')?.addEventListener('click', (e) => {
+    const btn = e.currentTarget as HTMLButtonElement;
+    const code = container.querySelector('#file-content-area code')?.textContent;
+
+    if (code && navigator.clipboard) {
+      void navigator.clipboard
+        .writeText(code)
+        .then(() => {
+          const originalText = btn.innerHTML;
+          btn.innerHTML = '✅ Copied!';
+          btn.classList.add('btn-primary');
+          btn.classList.remove('btn-ghost');
+
+          setTimeout(() => {
+            btn.innerHTML = originalText;
+            btn.classList.remove('btn-primary');
+            btn.classList.add('btn-ghost');
+          }, 2000);
+
+          toast.success('Copied to clipboard');
+        })
+        .catch((err) => {
+          safeError('[GistDetail] Clipboard copy failed', err);
+          toast.error('Failed to copy to clipboard');
+        });
+    } else if (code) {
+      toast.error('Clipboard API not available');
+    }
   });
 }
 

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -378,6 +378,22 @@ body {
   white-space: pre;
 }
 
+.file-info {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin: 0 var(--space-6) var(--space-8);
+  padding-top: var(--space-2);
+  border-top: 1px solid var(--color-divider);
+}
+
+.btn-copy-sm {
+  height: auto;
+  min-height: 0;
+  padding: var(--space-1) var(--space-2);
+}
+
 /* ===== Sync Indicator ===== */
 .sync-indicator {
   display: inline-flex;


### PR DESCRIPTION
This PR adds a highly requested micro-UX improvement: a "Copy to Clipboard" button in the Gist Detail view.

### 💡 What
Added a dedicated "Copy" button in the file metadata section of the Gist Detail view. When clicked, it copies the entire content of the currently viewed file to the user's clipboard.

### 🎯 Why
Previously, users had to manually select and copy code content, which can be cumbersome on mobile or for large files. This addition provides a one-click solution for a common workflow.

### ♿ Accessibility
- The button uses clear text ("Copy") and a descriptive emoji ("📋").
- Proper focus states and button semantics are maintained using the existing design system.
- Success and error states are announced via `toast` notifications (aria-live).

### ✨ Micro-UX Delight
- The button provides immediate visual confirmation by changing its label to "✅ Copied!" and its style to `btn-primary` for 2 seconds after a successful copy.
- Includes robust error handling and availability checks for the Clipboard API.

### 🛠 Technical Changes
- Modified `src/components/gist-detail.ts` to include the button and event logic.
- Added `.file-info` and `.btn-copy-sm` utility classes to `src/styles/base.css` to avoid brittle inline styles.
- Verified functionality and visual state using a custom Playwright script.

---
*PR created automatically by Jules for task [6218314293612728997](https://jules.google.com/task/6218314293612728997) started by @d-o-hub*