### PR TITLE
ci: fix SC2086 shellcheck error in cd workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -29,10 +29,10 @@ jobs:
       - name: Check if Pages is enabled
         id: check
         run: |
-          if gh api repos/${{ github.repository }}/pages --method GET 2>/dev/null; then
-            echo "enabled=true" >> $GITHUB_OUTPUT
+          if gh api repos/"${{ github.repository }}"/pages --method GET 2>/dev/null; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
           else
-            echo "enabled=false" >> $GITHUB_OUTPUT
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
             echo "::warning::GitHub Pages is not enabled. Skipping deployment."
           fi
         env:


### PR DESCRIPTION
This pull request fixes a shellcheck error (SC2086) in the `.github/workflows/cd.yml` workflow.

The issue occurred on line 32, where the `${{ github.repository }}` variable was used without double quotes, which could lead to globbing and word splitting issues.

**Changes:**
- Added double quotes around `${{ github.repository }}` on line 32.
- Additionally, added double quotes around `$GITHUB_OUTPUT` on lines 33 and 35 to prevent potential future warnings and maintain consistency.

---
*PR created automatically by Jules for task [18259664123583123159](https://jules.google.com/task/18259664123583123159) started by @d-o-hub*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed repository string formatting in the GitHub Pages deployment check within the CI/CD workflow to ensure proper API request handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->