### PR TITLE
🎨 Palette: Add Copy to Clipboard to Gist Detail

### DIFF
--- a/src/components/gist-detail.ts
+++ b/src/components/gist-detail.ts
@@ -91,8 +91,13 @@ export function renderGistDetail(gist: GistRecord): string {
         ${
           firstFile
             ? `
-          <span class="micro-label">Language: ${sanitizeHtml(firstFile.language || 'Unknown')}</span>
-          <span class="micro-label">Raw URL: <a href="${sanitizeHtml(firstFile.rawUrl || '')}" target="_blank" rel="noopener noreferrer">Link</a></span>
+          <div class="file-info-left">
+            <span class="micro-label">Language: ${sanitizeHtml(firstFile.language || 'Unknown')}</span>
+            <span class="micro-label">Raw URL: <a href="${sanitizeHtml(firstFile.rawUrl || '')}" target="_blank" rel="noopener noreferrer">Link</a></span>
+          </div>
+          <button class="btn btn-ghost btn-copy-sm" data-action="copy-content" aria-label="Copy file content">
+            <span class="micro-label">COPY</span>
+          </button>
         `
             : ''
         }
@@ -190,6 +195,88 @@ export function bindDetailEvents(
       if (ok) void loadGistDetail(gistId, container, onBack, onEdit, onViewRevision);
     })();
   });
+
+  // File Tabs
+  const tabs = container.querySelectorAll('.file-tab');
+  tabs.forEach((tab) => {
+    tab.addEventListener('click', () => {
+      const fileKey = (tab as HTMLElement).dataset.fileKey;
+      if (!fileKey) return;
+
+      // Update active tab UI
+      tabs.forEach((t) => {
+        t.classList.remove('active');
+        t.setAttribute('aria-selected', 'false');
+      });
+      tab.classList.add('active');
+      tab.setAttribute('aria-selected', 'true');
+
+      // Update content
+      void (async () => {
+        if (!gistId) return;
+        const gist = await (await import('../stores/gist-store')).default.getGist(gistId);
+        if (!gist) return;
+        const file = gist.files[fileKey];
+        if (!file) return;
+
+        const contentArea = container.querySelector('#file-content-area');
+        if (contentArea) {
+          contentArea.innerHTML = renderFileContent(file.content || '', file.language);
+          contentArea.setAttribute('aria-labelledby', tab.id);
+        }
+
+        const infoArea = container.querySelector('#file-info');
+        if (infoArea) {
+          infoArea.innerHTML = `
+            <div class="file-info-left">
+              <span class="micro-label">Language: ${sanitizeHtml(file.language || 'Unknown')}</span>
+              <span class="micro-label">Raw URL: <a href="${sanitizeHtml(file.rawUrl || '')}" target="_blank" rel="noopener noreferrer">Link</a></span>
+            </div>
+            <button class="btn btn-ghost btn-copy-sm" data-action="copy-content" aria-label="Copy file content">
+              <span class="micro-label">COPY</span>
+            </button>
+          `;
+        }
+      })();
+    });
+  });
+
+  // Copy Content
+  if (container.dataset.copyBound !== 'true') {
+    container.addEventListener('click', (e) => {
+      const copyBtn = (e.target as HTMLElement).closest(
+        '[data-action="copy-content"]'
+      ) as HTMLElement;
+      if (!copyBtn || copyBtn.classList.contains('btn-success')) return;
+
+      void (async () => {
+        const contentArea = container.querySelector('#file-content-area code');
+        if (!contentArea) return;
+
+        const text = contentArea.textContent || '';
+        try {
+          if (!navigator.clipboard) {
+            throw new Error('Clipboard API not available');
+          }
+          await navigator.clipboard.writeText(text);
+
+          const originalText = copyBtn.innerHTML;
+          copyBtn.innerHTML = '<span class="micro-label">✅ COPIED!</span>';
+          copyBtn.classList.add('btn-success');
+          toast.success('COPIED TO CLIPBOARD');
+
+          setTimeout(() => {
+            copyBtn.innerHTML = originalText;
+            copyBtn.classList.remove('btn-success');
+          }, 2000);
+        } catch (err) {
+          safeError('Failed to copy', err);
+          toast.error('COPY FAILED');
+        }
+      })();
+    });
+    container.dataset.copyBound = 'true';
+  }
 }
 
 function bindRevisionEvents(

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -472,6 +472,33 @@ body {
   white-space: pre;
 }
 
+.file-info {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--space-4);
+  padding: var(--space-4) var(--space-6);
+  border-top: 1px solid var(--color-border);
+}
+
+.file-info-left {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.btn-copy-sm {
+  min-height: 36px;
+  padding: var(--space-1) var(--space-3);
+  flex-shrink: 0;
+}
+
+.btn-success {
+  background: var(--color-status-success-subtle);
+  border-color: var(--color-success);
+  color: var(--color-success);
+}
+
 /* ===== Sync Indicator ===== */
 .sync-indicator {
   display: inline-flex;


### PR DESCRIPTION
💡 What: Enhanced the Gist Detail view with "Copy to Clipboard" functionality and improved multi-file tab navigation.

🎯 Why: Users need a quick way to copy file contents without manual selection, and multi-file Gists were not correctly switching between files, creating a frustrating experience.

📸 Before/After: Added a "COPY" button next to file metadata. Upon clicking, it provides immediate visual feedback ("✅ COPIED!") and a toast notification. File tabs now correctly refresh both the code and the file-specific information (language, raw link).

♿ Accessibility: Added `aria-label` to the copy button and ensured `aria-selected` and `aria-labelledby` are correctly updated during tab switching.

Changes verified via accessibility test suite and custom Playwright verification script.

---
*PR created automatically by Jules for task [15845713774163692143](https://jules.google.com/task/15845713774163692143) started by @d-o-hub*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * File tab switching: Navigate between multiple files in multi-file gists by clicking file tabs
  * Enhanced file information: View language type and raw URL for each file
  * Copy-to-clipboard: Copy file content with success/error notifications for user feedback

<!-- end of auto-generated comment: release notes by coderabbit.ai -->