### PR TITLE
fix: add skeleton detail CSS layout for gist-detail loading placeholder

### DIFF
--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -609,6 +609,42 @@ body {
   border-radius: var(--radius-card);
 }
 
+/* Detail skeleton — mirrors detail view structure */
+.gist-detail-skeleton {
+  display: flex;
+  flex-direction: column;
+}
+
+.skeleton-header {
+  padding: var(--space-8) var(--space-6) var(--space-6);
+  border-bottom: 1px solid var(--color-border);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.skeleton-content {
+  padding: var(--space-4) var(--space-6);
+}
+
+.skeleton-code-lines {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  padding: var(--space-4);
+  background: var(--color-surface-overlay);
+  border-radius: var(--radius-card);
+  margin-top: var(--space-4);
+}
+
+.skeleton-code-line {
+  height: 1rem;
+}
+
+.skeleton-file-tab {
+  margin-bottom: var(--space-4);
+}
+
 /* ===== Search and Filters ===== */
 .search-container {
   margin-bottom: var(--space-6);


### PR DESCRIPTION
## Summary

Add CSS layout styles for the `Skeleton.renderDetail()` placeholder to mirror the gist detail view structure.

## Changes

- **`src/styles/base.css`**: Added layout rules for `.gist-detail-skeleton`, `.skeleton-header`, `.skeleton-content`, `.skeleton-code-lines`, `.skeleton-code-line`, and `.skeleton-file-tab`
- `.skeleton-header` mirrors `.detail-header` (padding, border-bottom, gap)
- `.skeleton-code-lines` mirrors `.file-content-area` (background, border-radius, padding)
- `.skeleton-content` provides horizontal padding matching the detail view
- `.skeleton-file-tab` has `margin-bottom` spacing for the file tab placeholder

## Why

The `Skeleton.renderDetail()` method already existed in `skeleton.ts` but had no CSS layout — only the `.loading-skeleton` shimmer animation was styled. These new rules give the skeleton placeholder proper structure that visually approximates the real detail view while the gist loads async.

## Validation

- typecheck ✅
- lint ✅
- format ✅


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Implemented comprehensive skeleton UI styling for detail view loading states. New visual indicators now appear for headers, content sections, code displays, and file tabs, creating a more polished and consistent loading experience throughout the application.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/d-o-hub/do-gist-hub/pull/147)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->