### PR TITLE
fix: prevent footer-max-line-length CI failures and remove `any` types

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,11 @@ pnpm run test:unit
 - **Strict Types**: No `any`. Explicit returns.
 - **No Static-Only Classes**: `export class Foo { static ... }` → `export const Foo = { ... }`. Module-level helpers for private methods. (ADR-026)
 - **Tools**: Format and Lint with Biome (`pnpm run lint:fix`).
-- **Commits**: Conventional Commits only (`feat:`, `fix:`, `chore:`, etc.).
+- **Commits**: Conventional Commits only (`feat:`, `fix:`, `chore:`, etc.). Line limits: header 150, body 200, footer 200.
+- **Commit-msg Hook**: Install locally to catch format errors before push:
+  ```bash
+  cp scripts/commit-msg-hook.sh .git/hooks/commit-msg && chmod +x .git/hooks/commit-msg
+  ```
 - **Style**: Direct, professional. No conversational filler or emojis in generated docs.
 
 ## Architecture

--- a/agents-docs/self-learning-rules.md
+++ b/agents-docs/self-learning-rules.md
@@ -36,6 +36,7 @@
 | `ts_any_type` | TypeScript `any` usage | Medium |
 | `html_unstyled_button` | Button without CSS class | High |
 | `ts_noStaticOnlyClass` | Class with only static members (refactor to object literal) | Medium |
+| `commit_footer_max_length` | Commit footer/body line exceeds 100 chars (commitlint default) | Medium |
 
 ## Autonomous Optimization
 

--- a/agents-docs/self-learning-rules.md
+++ b/agents-docs/self-learning-rules.md
@@ -37,6 +37,7 @@
 | `html_unstyled_button` | Button without CSS class | High |
 | `ts_noStaticOnlyClass` | Class with only static members (refactor to object literal) | Medium |
 | `commit_footer_max_length` | Commit footer/body line exceeds 100 chars (commitlint default) | Medium |
+| `idb_boolean_index_key` | IndexedDB schema indexes boolean properties, but TS DOM `IDBValidKey` excludes boolean | Medium |
 
 ## Autonomous Optimization
 

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -4,6 +4,7 @@ export default {
     'type-enum': [2, 'always', ['build', 'merge', 'chore', 'ci', 'docs', 'feat', 'fix', 'perf', 'refactor', 'revert', 'style', 'test', 'plans']],
     'header-max-length': [2, 'always', 150],
     'body-max-line-length': [2, 'always', 200],
+    'footer-max-line-length': [2, 'always', 200],
   },
   ignores: [
     (commit) => /^Merge (branch|pull request)/.test(commit),

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "cap:android:open": "npx cap open android",
     "build:android": "pnpm run build && pnpm run cap:sync",
     "analyze": "ANALYZE=true pnpm run build",
+    "commitlint:last": "commitlint --from=HEAD~1 --to=HEAD --verbose",
     "quality": "./scripts/quality_gate.sh"
   },
   "dependencies": {

--- a/plans/025-progress-update-2026-07-18.md
+++ b/plans/025-progress-update-2026-07-18.md
@@ -45,6 +45,16 @@ ADR-026 (GOAP Actions): ErrorBoundary/EmptyState refactor not done. TS6 deprecat
 - All 3 callers (home.ts, offline.ts, conflict-resolution.ts) use `EmptyState.render()` — no API change needed.
 - Fixes Biome `noStaticOnlyClass` violation.
 
+## Subsequent Fixes (post-2026-07-18)
+
+### Commitlint Footer Line Length + Type Safety
+- `commitlint.config.mjs`: Added `footer-max-line-length: [2, 'always', 200]` to prevent CI failures when commitlint body lines are parsed as footer lines (was default 100).
+- `AGENTS.md`: Documented commit line limits (header 150, body 200, footer 200) and added commit-msg hook installation instructions.
+- `package.json`: Added `"commitlint:last"` script for local validation of the most recent commit.
+- `scripts/pre-commit-hook.sh`: Added warning when commit-msg hook is not installed.
+- `src/services/db.ts`: Removed `DBSchemaIndex` alias and `[key: string]` index signature from `GistDBSchema`; changed `by-starred: boolean` to `number` to satisfy `IDBValidKey` constraint.
+- `src/services/pwa/register-sw.ts`: Replaced `any` cast with typed `ServiceWorkerRegistration & { sync: SyncManager }`.
+
 ## Remaining P0/P1 Items
 - P0-1: Fix Playwright navigation test failures (CI-blocking, root cause: CSS display:none not overridden in test viewport)
 - P1-5: Build RouteBoundary component

--- a/scripts/pre-commit-hook.sh
+++ b/scripts/pre-commit-hook.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 # Guard Rails: Prevent global hooks from overriding local
 GLOBAL_HOOKS_PATH=$(git config --global core.hooksPath 2>/dev/null || echo "")
 if [[ -n "$GLOBAL_HOOKS_PATH" && -z "${SKIP_GLOBAL_HOOKS_CHECK:-}" ]]; then
@@ -9,11 +11,15 @@ if [[ -n "$GLOBAL_HOOKS_PATH" && -z "${SKIP_GLOBAL_HOOKS_CHECK:-}" ]]; then
   exit 1
 fi
 
+# Warn if commit-msg hook is not installed (prevents late CI failures)
+if [[ ! -f "$SCRIPT_DIR/../.git/hooks/commit-msg" ]]; then
+  echo "⚠️  commit-msg hook not installed. Run: cp scripts/commit-msg-hook.sh .git/hooks/commit-msg && chmod +x .git/hooks/commit-msg"
+fi
+
 # Run lint-staged on staged files only
 if command -v npx >/dev/null 2>&1; then
   npx lint-staged
 fi
 
 # Run quality gate
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 "$SCRIPT_DIR/quality_gate.sh"

--- a/src/services/db.ts
+++ b/src/services/db.ts
@@ -21,7 +21,10 @@ export interface GistDBSchema extends DBSchema {
     value: GistRecord;
     indexes: {
       'by-updated-at': string;
-      'by-starred': boolean;
+      // ⚠️ Type-level mismatch: IndexedDB stores boolean values at runtime, but
+      // TypeScript DOM types restrict IDBValidKey to number|string|Date|BufferSource|Array.
+      // Querying this index via idb APIs requires numeric arguments at compile time.
+      'by-starred': number;
       'by-sync-status': string;
     };
   };

--- a/src/services/db.ts
+++ b/src/services/db.ts
@@ -12,9 +12,6 @@ import { APP } from '@/config/app.config';
 const DB_VERSION = 3;
 const DB_NAME = APP.dbName;
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type DBSchemaIndex = any;
-
 /**
  * Database Schema Definition
  */
@@ -52,7 +49,6 @@ export interface GistDBSchema extends DBSchema {
       'by-level': string;
     };
   };
-  [key: string]: DBSchemaIndex;
 }
 
 /**

--- a/src/services/pwa/register-sw.ts
+++ b/src/services/pwa/register-sw.ts
@@ -69,6 +69,13 @@ export async function clearCaches(): Promise<void> {
 }
 
 /**
+ * Background Sync API (not yet in standard TS lib types)
+ */
+interface SyncManager {
+  register(tag: string): Promise<void>;
+}
+
+/**
  * Notify user of update (placeholder - can be enhanced with UI)
  */
 function notifyUpdateAvailable(): void {
@@ -93,8 +100,7 @@ export async function requestBackgroundSync(): Promise<boolean> {
 
   try {
     const registration = await navigator.serviceWorker.ready;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    await (registration as any).sync?.register('sync-gists');
+    await (registration as ServiceWorkerRegistration & { sync: SyncManager }).sync.register('sync-gists');
     safeLog('[PWA] Background sync registered');
     return true;
   } catch (error) {

--- a/src/services/pwa/register-sw.ts
+++ b/src/services/pwa/register-sw.ts
@@ -100,7 +100,9 @@ export async function requestBackgroundSync(): Promise<boolean> {
 
   try {
     const registration = await navigator.serviceWorker.ready;
-    await (registration as ServiceWorkerRegistration & { sync: SyncManager }).sync.register('sync-gists');
+    await (registration as ServiceWorkerRegistration & { sync: SyncManager }).sync.register(
+      'sync-gists'
+    );
     safeLog('[PWA] Background sync registered');
     return true;
   } catch (error) {


### PR DESCRIPTION
Set footer-max-line-length to 200 in commitlint.config.mjs.

Document commit line limits in AGENTS.md.

Add commitlint:last script for local validation.

Warn when commit-msg hook is missing in pre-commit-hook.sh.

Add commit_footer_max_length to self-learning-rules.md.

Remove `any` alias and index signature from db.ts schema.

Replace `any` cast with SyncManager interface in register-sw.ts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated contribution guidance with conventional commit requirements, explicit commit-message line-length limits, and a local commit-msg hook install instruction.

* **Chores**
  * Added footer line-length validation for commit messages.
  * Added a script to lint the most recent commit with verbose output.
  * Enhanced pre-commit checks to warn when commit-msg hook is missing and suggest installation.
  * Improved internal service-layer type safety.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/d-o-hub/do-gist-hub/pull/148)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->