### PR TITLE
feat: PWA update toast, dead code removal, and token-driven CSS utilities

### DIFF
--- a/src/components/ui/command-palette.ts
+++ b/src/components/ui/command-palette.ts
@@ -38,6 +38,7 @@ export class CommandPalette {
 
     this.container = document.createElement('div');
     this.container.className = 'command-palette';
+    this.container.setAttribute('data-testid', 'command-palette');
     this.container.setAttribute('role', 'combobox');
     this.container.setAttribute('aria-expanded', 'false');
     this.container.setAttribute('aria-haspopup', 'listbox');

--- a/src/components/ui/toast.ts
+++ b/src/components/ui/toast.ts
@@ -7,6 +7,11 @@ import { sanitizeHtml } from '../../services/security';
 
 export type ToastType = 'success' | 'error' | 'info' | 'warning';
 
+export interface ToastAction {
+  label: string;
+  onClick: () => void;
+}
+
 export class ToastManager {
   private container: HTMLElement | null = null;
   private toasts: Map<string, HTMLElement> = new Map();
@@ -41,7 +46,7 @@ export class ToastManager {
     return this.container;
   }
 
-  show(message: string, type: ToastType = 'info', durationMs = 4000): string {
+  show(message: string, type: ToastType = 'info', durationMs = 4000, action?: ToastAction): string {
     const id = `toast-${++this.idCounter}`;
     const container = this.getContainer();
 
@@ -51,13 +56,27 @@ export class ToastManager {
     toast.classList.add('toast', `toast-${type}`, 'toast-enter');
     toast.style.pointerEvents = 'auto';
 
+    const actionHtml = action
+      ? `<button class="toast-action btn btn-ghost" type="button">${sanitizeHtml(action.label)}</button>`
+      : '';
+
     toast.innerHTML = `
       <span class="toast-message">${sanitizeHtml(message)}</span>
+      ${actionHtml}
       <button class="toast-close" aria-label="Dismiss notification" type="button">×</button>
     `;
 
     container.appendChild(toast);
     this.toasts.set(id, toast);
+
+    // Action handler
+    if (action) {
+      const actionBtn = toast.querySelector('.toast-action');
+      actionBtn?.addEventListener('click', () => {
+        action.onClick();
+        this.dismiss(id);
+      });
+    }
 
     // Close handler
     const closeBtn = toast.querySelector('.toast-close');
@@ -71,21 +90,21 @@ export class ToastManager {
     return id;
   }
 
-  success(message: string, durationMs?: number): string {
-    return this.show(message, 'success', durationMs);
+  success(message: string, durationMs?: number, action?: ToastAction): string {
+    return this.show(message, 'success', durationMs, action);
   }
 
-  error(message: string, durationMs?: number): string {
+  error(message: string, durationMs?: number, action?: ToastAction): string {
     // Errors stay longer so users can read them
-    return this.show(message, 'error', durationMs ?? 6000);
+    return this.show(message, 'error', durationMs ?? 6000, action);
   }
 
-  info(message: string, durationMs?: number): string {
-    return this.show(message, 'info', durationMs);
+  info(message: string, durationMs?: number, action?: ToastAction): string {
+    return this.show(message, 'info', durationMs, action);
   }
 
-  warn(message: string, durationMs?: number): string {
-    return this.show(message, 'warning', durationMs);
+  warn(message: string, durationMs?: number, action?: ToastAction): string {
+    return this.show(message, 'warning', durationMs, action);
   }
 
   dismiss(id: string): void {

--- a/src/routes/create.ts
+++ b/src/routes/create.ts
@@ -11,21 +11,6 @@ function createFileRow(id: number, container: HTMLElement): HTMLElement {
   const div = document.createElement('div');
   div.className = 'file-entry';
   div.innerHTML = `
-    <div class="file-entry-header">
-      <div class="form-group">
-        <label class="form-label" for="gist-filename-${id}">Filename</label>
-        <input type="text" id="gist-filename-${id}" class="form-input gist-filename" placeholder="e.g. index.js" required>
-      </div>
-      <button type="button" class="btn btn-ghost btn-remove-file" data-file-id="${id}">
-          REMOVE
-        </button>
-    </div>
-    <div class="form-group">
-      <label class="form-label" for="gist-content-${id}">Content</label>
-      <textarea id="gist-content-${id}" class="form-textarea gist-content" placeholder="File content..." required></textarea>
-    </div>
-  `;
-  div.innerHTML = `
     <div class="flex-row gap-2 flex-end">
       <div class="form-group flex-1 mb-0">
         <label class="form-label" for="gist-filename-${id}">Filename</label>
@@ -35,9 +20,9 @@ function createFileRow(id: number, container: HTMLElement): HTMLElement {
           REMOVE
         </button>
     </div>
-    <div class="form-group" style="margin-bottom: 0;">
+    <div class="form-group mb-0">
       <label class="form-label" for="gist-content-${id}">Content</label>
-      <textarea id="gist-content-${id}" class="form-textarea gist-content" placeholder="File content..." required style="min-height: 160px;"></textarea>
+      <textarea id="gist-content-${id}" class="form-textarea gist-content gist-content-minh" placeholder="File content..." required></textarea>
     </div>
   `;
 

--- a/src/routes/offline.ts
+++ b/src/routes/offline.ts
@@ -56,7 +56,7 @@ async function updateOfflineStatus(container: HTMLElement): Promise<void> {
   if (opsEl) {
     const content =
       count > 0
-        ? `<div class="glass-card p-6" style="text-align: center;">
+        ? `<div class="glass-card p-6 text-center">
              <p class="micro-label">${sanitizeHtml(String(count))} operation${count !== 1 ? 's' : ''} waiting for connection</p>
            </div>`
         : EmptyState.render({

--- a/src/services/pwa/register-sw.ts
+++ b/src/services/pwa/register-sw.ts
@@ -1,3 +1,4 @@
+import { toast } from '../../components/ui/toast';
 import { safeError, safeLog, safeWarn } from '../security/logger';
 /**
  * Service Worker Registration
@@ -76,11 +77,13 @@ interface SyncManager {
 }
 
 /**
- * Notify user of update (placeholder - can be enhanced with UI)
+ * Notify user of update via toast notification
  */
 function notifyUpdateAvailable(): void {
-  // Could show a toast or banner: "New version available. Refresh to update."
-  safeLog('[PWA] Update available - refresh to get latest version');
+  toast.info('New version available — refresh to update', 0, {
+    label: 'Refresh',
+    onClick: () => window.location.reload(),
+  });
 }
 
 /**

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -1055,6 +1055,23 @@ textarea.form-textarea {
   min-height: auto;
 }
 
+.text-center {
+  text-align: center;
+}
+
+.gist-content-minh {
+  min-height: 160px;
+}
+
+/* ===== Toast Action Button ===== */
+.toast-action {
+  margin-left: auto;
+  padding: var(--spacing-2) var(--spacing-3);
+  min-height: var(--spacing-9);
+  font-size: var(--font-size-sm);
+  white-space: nowrap;
+}
+
 /* ===== Bento Grid Dashboard ===== */
 .gist-grid {
   display: grid;


### PR DESCRIPTION
## What's Changed\n\n- **PWA update notification** — Replaced placeholder  in  with real  notification including a Refresh action button (ADR-022 progressive enhancement).\n- **Toast action support** — Extended  with  interface and  parameter across all variant methods.\n- **Dead code removal** — Removed double  assignment in  file row builder.\n- **Token-driven utilities** — Replaced remaining hardcoded inline styles with utility classes (, , ).\n- **Testability** — Added  to command palette container for Playwright selectors.\n- **CSS** — Added  styles to  using token-driven values.\n\n## Validation\n\n- [x] 
> d-o-gist-hub@0.1.0 lint /home/do/git/do-gist-hub
> biome check src

Checked 77 files in 32ms. No fixes applied. — 0 errors, 0 warnings\n- [x] 
> d-o-gist-hub@0.1.0 typecheck /home/do/git/do-gist-hub
> tsc --noEmit — 0 errors\n- [x] 
> d-o-gist-hub@0.1.0 build /home/do/git/do-gist-hub
> tsc --noEmit && vite build

vite v8.0.11 building client environment for production...
[2Ktransforming...✓ 75 modules transformed.
rendering chunks...
computing gzip size...
dist/index.html                                                    2.29 kB │ gzip:  0.93 kB
dist/assets/anton-vietnamese-400-normal-2FfR1wHA.woff              6.82 kB
dist/assets/jetbrains-mono-vietnamese-wght-normal-Bt-aOZkq.woff2   7.50 kB
dist/assets/anton-vietnamese-400-normal-CkBxLiRJ.woff2             8.68 kB
dist/assets/jetbrains-mono-greek-wght-normal-Bw9x6K1M.woff2        9.00 kB
dist/assets/inter-vietnamese-wght-normal-CBcvBZtf.woff2           10.25 kB
dist/assets/inter-greek-ext-wght-normal-DlzME5K_.woff2            11.23 kB
dist/assets/jetbrains-mono-cyrillic-wght-normal-D73BlboJ.woff2    12.10 kB
dist/assets/jetbrains-mono-latin-ext-wght-normal-DBQx-q_a.woff2   15.19 kB
dist/assets/anton-latin-400-normal-AUNGEG_V.woff                  15.63 kB
dist/assets/anton-latin-400-normal-Byf51wtH.woff2                 18.61 kB
dist/assets/inter-cyrillic-wght-normal-DqGufNeO.woff2             18.74 kB
dist/assets/inter-greek-wght-normal-CkhJZR-_.woff2                18.99 kB
dist/assets/inter-cyrillic-ext-wght-normal-BOeWTOD4.woff2         25.96 kB
dist/assets/anton-latin-ext-400-normal-BMODBQc6.woff              28.07 kB
dist/assets/anton-latin-ext-400-normal-SyiqE2Jt.woff2             31.35 kB
dist/assets/jetbrains-mono-latin-wght-normal-B9CIFXIH.woff2       40.40 kB
dist/assets/inter-latin-wght-normal-Dx4kXJAl.woff2                48.25 kB
dist/assets/inter-latin-ext-wght-normal-DO1Apj_S.woff2            85.06 kB
dist/assets/vendor-tgJmM6jX.css                                    7.59 kB │ gzip:  2.93 kB
dist/assets/index-BJGDlQVQ.css                                    44.45 kB │ gzip:  7.51 kB
dist/assets/dialog-D5hLaMuq.js                                     0.95 kB │ gzip:  0.51 kB │ map:   2.20 kB
dist/assets/preload-helper-DnOHA2jP.js                             1.21 kB │ gzip:  0.70 kB
dist/assets/export-import-DGEt1SCk.js                              1.92 kB │ gzip:  1.00 kB │ map:   6.74 kB
dist/assets/skeleton-BVjx_JAy.js                                   2.24 kB │ gzip:  0.49 kB │ map:   2.97 kB
dist/assets/toast-42M5N6ko.js                                      2.45 kB │ gzip:  1.08 kB │ map:   7.61 kB
dist/assets/conflict-detector-BubqLZEF.js                          2.57 kB │ gzip:  1.16 kB │ map:   8.43 kB
dist/assets/logger-D2UnLt9x.js                                     5.48 kB │ gzip:  2.23 kB │ map:  22.86 kB
dist/assets/conflict-resolution-rPyraoAq.js                        5.68 kB │ gzip:  1.57 kB │ map:  11.34 kB
dist/assets/home-Dts4RX9c.js                                       6.02 kB │ gzip:  2.34 kB │ map:  15.79 kB
dist/assets/settings-o1P2f9CC.js                                   6.93 kB │ gzip:  2.14 kB │ map:  11.18 kB
dist/assets/gist-detail-DyfKoVoP.js                                8.03 kB │ gzip:  2.77 kB │ map:  16.73 kB
dist/assets/vendor-ob08lewm.js                                     8.74 kB │ gzip:  3.47 kB │ map:  28.89 kB
dist/assets/auth-Dy8XVFBF.js                                       9.86 kB │ gzip:  3.53 kB │ map:  35.84 kB
dist/assets/gist-store-C4zHk2vR.js                                11.48 kB │ gzip:  3.75 kB │ map:  39.07 kB
dist/assets/index-BMCtIU3g.js                                     51.80 kB │ gzip: 13.98 kB │ map: 118.75 kB

✓ built in 177ms

✓ Performance budgets passed
✓ Service Worker generated: dist/sw.js — success\n- [x] 
> d-o-gist-hub@0.1.0 test:unit /home/do/git/do-gist-hub
> vitest run


[1m[30m[46m RUN [49m[39m[22m [36mv4.1.5 [39m[90m/home/do/git/do-gist-hub[39m

 [32m✓[39m tests/unit/gist-store.test.ts [2m([22m[2m12 tests[22m[2m)[22m[32m 15[2mms[22m[39m
 [32m✓[39m tests/unit/auth.test.ts [2m([22m[2m16 tests[22m[2m)[22m[32m 18[2mms[22m[39m
 [32m✓[39m tests/unit/security-dom.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 5[2mms[22m[39m
 [32m✓[39m tests/unit/auth-service.test.ts [2m([22m[2m11 tests[22m[2m)[22m[32m 18[2mms[22m[39m
 [32m✓[39m tests/unit/crypto.test.ts [2m([22m[2m13 tests[22m[2m)[22m[32m 66[2mms[22m[39m
 [32m✓[39m tests/unit/lifecycle.test.ts [2m([22m[2m9 tests[22m[2m)[22m[32m 18[2mms[22m[39m
 [32m✓[39m tests/unit/github-client.test.ts [2m([22m[2m18 tests[22m[2m)[22m[32m 45[2mms[22m[39m
 [32m✓[39m tests/unit/security-logger.test.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 14[2mms[22m[39m
 [32m✓[39m tests/unit/db-security.test.ts [2m([22m[2m1 test[22m[2m)[22m[32m 26[2mms[22m[39m
 [32m✓[39m tests/unit/sync-queue.test.ts [2m([22m[2m16 tests[22m[2m)[22m[32m 49[2mms[22m[39m
 [32m✓[39m tests/unit/db.test.ts [2m([22m[2m25 tests[22m[2m)[22m[32m 80[2mms[22m[39m

[2m Test Files [22m [1m[32m11 passed[39m[22m[90m (11)[39m
[2m      Tests [22m [1m[32m130 passed[39m[22m[90m (130)[39m
[2m   Start at [22m 20:41:45
[2m   Duration [22m 1.63s[2m (transform 1.25s, setup 0ms, import 1.87s, tests 353ms, environment 12.19s)[22m — 130 tests passed\n- [x] Running quality gates...
✓ Skill validation passed

✓ All quality gates passed — passed\n\n## Breaking Changes\n\nNone.