### PR TITLE
⚡ Bolt: Optimized Gist list processing and card rendering

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -7,3 +7,7 @@
 ## 2026-05-07 - Persistent Timestamp Caching
 **Learning:** Local Map-based caches within render functions (e.g., for Date.parse) are ineffective across renders. Moving the cache to module or static scope significantly improves sorting performance for large lists by avoiding redundant O(N log N) parsing.
 **Action:** Always prefer module-level or static class-level persistent caches for expensive data transformations used in sort loops. Use the source string itself as the key to ensure cache validity.
+
+## 2026-05-08 - Schwartzian Transform & Cache Coherency
+**Learning:** Even with timestamp caching, $O(N \log N)$ sorting still performs $N \log N$ Map lookups. Implementing a Schwartzian Transform reduces this to exactly $N$ lookups. Also, UI component caches (like gist cards) must include ALL mutable state (e.g., `starred`) in the cache key, as local optimistic updates might change state without updating the `updatedAt` timestamp.
+**Action:** Use Schwartzian Transform for all critical-path sort operations. Ensure UI cache keys represent the full visual state, not just server timestamps.

--- a/src/components/gist-card.ts
+++ b/src/components/gist-card.ts
@@ -10,9 +10,9 @@ import { showConfirmDialog } from '../utils/dialog';
 import { toast } from './ui/toast';
 
 function formatRelativeTime(dateStr: string): string {
-  const now = new Date();
-  const date = new Date(dateStr);
-  const diffMs = now.getTime() - date.getTime();
+  const now = Date.now();
+  const dateTs = Date.parse(dateStr);
+  const diffMs = now - dateTs;
   const diffSec = Math.floor(diffMs / 1000);
   if (diffSec < 60) return 'JUST NOW';
   const diffMin = Math.floor(diffSec / 60);
@@ -23,11 +23,13 @@ function formatRelativeTime(dateStr: string): string {
   return `${diffDay}D AGO`;
 }
 
-const cardCache = new Map<string, { html: string; updatedAt: string }>();
+const cardCache = new Map<string, { html: string; updatedAt: string; starred: boolean }>();
 
 export function renderCard(gist: GistRecord): string {
   const cached = cardCache.get(gist.id);
-  if (cached && cached.updatedAt === gist.updatedAt) return cached.html;
+  // BOLT: Fix stale cache bug by including starred status in the check
+  if (cached && cached.updatedAt === gist.updatedAt && cached.starred === gist.starred)
+    return cached.html;
 
   const fileCount = Object.keys(gist.files).length;
   const firstFile = Object.values(gist.files)[0];
@@ -72,7 +74,7 @@ export function renderCard(gist: GistRecord): string {
     </article>
   `;
 
-  cardCache.set(gist.id, { html, updatedAt: gist.updatedAt });
+  cardCache.set(gist.id, { html, updatedAt: gist.updatedAt, starred: gist.starred });
   return html;
 }
 

--- a/src/routes/home.ts
+++ b/src/routes/home.ts
@@ -72,26 +72,32 @@ export function render(container: HTMLElement, params?: Record<string, string>):
 
     if (searchQuery) {
       const q = searchQuery.toLowerCase();
-      gists = gists.filter(
-        (g) =>
-          g.description?.toLowerCase().includes(q) ||
-          Object.values(g.files).some((f) => f.filename.toLowerCase().includes(q))
-      );
+      gists = gists.filter((g) => {
+        if (g.description?.toLowerCase().includes(q)) return true;
+        // BOLT: Efficient file search avoiding Object.values() array allocation
+        for (const filename in g.files) {
+          if (filename.toLowerCase().includes(q)) return true;
+        }
+        return false;
+      });
     }
 
-    // BOLT: Optimize sorting by pre-parsing timestamps with persistent cache
-    gists = [...gists].sort((a, b) => {
-      if (currentSort === 'created-desc') {
-        return getTs(b.createdAt) - getTs(a.createdAt);
-      }
-      if (currentSort === 'updated-desc') {
-        return getTs(b.updatedAt) - getTs(a.updatedAt);
-      }
-      if (currentSort === 'updated-asc') {
-        return getTs(a.updatedAt) - getTs(b.updatedAt);
-      }
-      return 0;
-    });
+    // BOLT: Optimize by skipping sorting when the order matches the store's natural order (updated-desc).
+    // The store already maintains gists sorted by updatedAt descending.
+    if (currentSort !== 'updated-desc' || searchQuery) {
+      gists = [...gists].sort((a, b) => {
+        if (currentSort === 'created-desc') {
+          return getTs(b.createdAt) - getTs(a.createdAt);
+        }
+        if (currentSort === 'updated-desc') {
+          return getTs(b.updatedAt) - getTs(a.updatedAt);
+        }
+        if (currentSort === 'updated-asc') {
+          return getTs(a.updatedAt) - getTs(b.updatedAt);
+        }
+        return 0;
+      });
+    }
 
     if (gists.length === 0) {
       if (searchQuery) {

--- a/src/stores/gist-store.ts
+++ b/src/stores/gist-store.ts
@@ -100,7 +100,10 @@ class GistStore {
 
       const processedRecords: GistRecord[] = [];
       const newConflicts: GistConflict[] = [];
-      const gistMap = new Map(this.gists.map((g) => [g.id, g]));
+
+      // BOLT: Avoid array-of-pairs allocation by using a simple loop to build the map
+      const gistMap = new Map<string, GistRecord>();
+      for (const g of this.gists) gistMap.set(g.id, g);
 
       // BOLT: Optimize by processing all gists in parallel and batching DB writes
       const processGist = (gist: GitHubGist, isStarred: boolean): void => {
@@ -131,8 +134,6 @@ class GistStore {
         }
       }
 
-      // Parallel processing complete
-
       // BOLT: Batch store conflicts to prevent race conditions
       if (newConflicts.length > 0) {
         await storeConflicts(newConflicts);
@@ -141,13 +142,11 @@ class GistStore {
       // BOLT: Use new batch save method
       await saveGists(processedRecords);
 
-      // BOLT: Only update in-memory state after successful DB write
-      // Use Map for O(1) lookups during merge to achieve O(N + M) complexity
-      const currentGistMap = new Map(this.gists.map((g) => [g.id, g]));
+      // BOLT: Reuse existing map to update in-memory state, avoiding second map reconstruction
       for (const record of processedRecords) {
-        currentGistMap.set(record.id, record);
+        gistMap.set(record.id, record);
       }
-      this.gists = Array.from(currentGistMap.values());
+      this.gists = Array.from(gistMap.values());
 
       this.sortGists();
     } catch (err) {
@@ -462,7 +461,7 @@ class GistStore {
 
   /**
    * Sort gists by updatedAt descending.
-   * BOLT: Optimize by pre-parsing timestamps to avoid O(N log N) Date.parse calls.
+   * BOLT: Implement Schwartzian Transform to reduce timestamp lookups from O(N log N) to O(N).
    */
   private sortGists(): void {
     const getTimestamp = (dateStr: string): number => {
@@ -474,11 +473,11 @@ class GistStore {
       return ts;
     };
 
-    this.gists.sort((a, b) => {
-      const tsB = getTimestamp(b.updatedAt);
-      const tsA = getTimestamp(a.updatedAt);
-      return tsB - tsA;
-    });
+    // Schwartzian Transform: map to temp objects with timestamps, sort, map back
+    this.gists = this.gists
+      .map((gist) => ({ gist, ts: getTimestamp(gist.updatedAt) }))
+      .sort((a, b) => b.ts - a.ts)
+      .map((item) => item.gist);
   }
 }
 


### PR DESCRIPTION
💡 What:
- Implemented Schwartzian Transform in `GistStore.sortGists` to reduce Map lookups from $O(N \log N)$ to $O(N)$.
- Optimized `loadGists` to avoid redundant `Map` reconstructions and array allocations.
- Added a fast-path in `Home` route to skip sorting when the order matches the store's default.
- Refactored Home route search filter to use an efficient `for...in` loop, avoiding `Object.values()` allocations.
- Refactored `formatRelativeTime` in `gist-card.ts` to use `Date.now()` and `Date.parse()`, eliminating per-card `Date` object creation.
- Fixed a stale UI bug in `renderCard` cache by including the `starred` status in the cache key.

🎯 Why:
- Reduces main thread blocking during list renders and search filtering.
- Minimizes garbage collection pressure by reducing short-lived object and array allocations.
- Ensures UI consistency during optimistic local updates.

📊 Impact:
- Sorting gists is now $O(N)$ for lookups.
- Card rendering is faster with zero `Date` object instantiation per card.
- Search filtering is more memory-efficient.

🔬 Measurement:
- Verified via 937 passing unit tests.
- Visual verification with Playwright confirms search functionality is intact.

---
*PR created automatically by Jules for task [11945415751102722198](https://jules.google.com/task/11945415751102722198) started by @d-o-hub*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed gist card cache invalidation to properly reflect changes to starred status.

* **Performance Improvements**
  * Optimized search filtering mechanism for faster results.
  * Improved sorting algorithm efficiency.
  * Streamlined data store record processing and batching operations.
  * Enhanced timestamp calculations for relative time displays.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/d-o-hub/do-gist-hub/pull/159)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->