### PR TITLE
feat: complete plan 042 — SW TTL cache expiry and plan status updates

### DIFF
--- a/plans/040-goap-phase-d-039-phase-bc-completion.md
+++ b/plans/040-goap-phase-d-039-phase-bc-completion.md
@@ -2,7 +2,7 @@
 
 > **Date**: 2026-05-17
 > **Type**: GOAP Plan
-> **Status**: Complete
+> **Status**: Complete ✅
 > **Related**: `039-ui-ux-2026-modernization.md`, `038-codebase-audit-recommendations-2026-05-16.md`, `adr-022-2026-ui-trends-recommendations.md`
 
 ## Context

--- a/plans/042-goap-plans-completion-sprint.md
+++ b/plans/042-goap-plans-completion-sprint.md
@@ -2,7 +2,7 @@
 
 > **Date**: 2026-05-17
 > **Type**: GOAP Plan
-> **Status**: Active
+> **Status**: Complete ✅
 > **Related**: `041-goap-release-signing-and-plan040-completion.md`, `040-goap-phase-d-039-phase-bc-completion.md`, `adr-015-upstream-template-adaptation.md`, `019-swarm-analysis-codebase-improvements.md`
 
 ---

--- a/plans/043-progress-update-2026-05-17-plan042-completion.md
+++ b/plans/043-progress-update-2026-05-17-plan042-completion.md
@@ -1,0 +1,39 @@
+# Progress Update: Plan 042 Completion — SW TTL, Plan Status Updates
+
+> **Date**: 2026-05-17
+> **Branch**: `plan042-completion-sw-ttl`
+> **Related Plans**: `042-goap-plans-completion-sprint.md`, `040-goap-phase-d-039-phase-bc-completion.md`
+
+---
+
+## Executive Summary
+
+### Key Achievements
+- Implemented SW TTL-based cache entry expiration (30-day max-age)
+- Marked Plan 042 complete, fixed Plan 040 status header
+- Updated all plan registries (_status.json, _index.md, README.md)
+
+---
+
+## Implementation Details
+
+### Files Modified
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `src/sw/sw.ts` | EDIT | Add TTL-based cache entry cleanup (CACHE_MAX_AGE_MS, addTimestampToResponse, isResponseExpired, cleanExpiredEntries) |
+| `plans/042-goap-plans-completion-sprint.md` | EDIT | "Active" → "Complete ✅" |
+| `plans/040-goap-phase-d-039-phase-bc-completion.md` | EDIT | "Complete" → "Complete ✅" |
+| `plans/_status.json` | EDIT | Plan 042 status → complete, nextAvailable plan → 043 |
+| `plans/_index.md` | EDIT | Plan 042 → Complete, plan number → 043 |
+| `plans/README.md` | EDIT | Next available plan number → 043 |
+
+---
+
+## Validation
+
+- TypeScript: `tsc --noEmit` — pass
+- Lint: `biome check src` — zero errors
+- Tests: 963 tests, 53 files — all pass
+- Coverage: 91.64% statements, 94.08% lines — all thresholds met
+- Quality Gate: All checks passed

--- a/plans/README.md
+++ b/plans/README.md
@@ -36,7 +36,7 @@ plans/
 ## Naming conventions
 
 - Numbers zero-padded to 3 digits: `000`, `001`, `002`
-- **Next available plan number**: `042`
+- **Next available plan number**: `043`
 - **Next available ADR number**: `adr-030`
 - Dates: ISO 8601 `YYYY-MM-DD`
 - Slugs: lowercase kebab-case, max 40 chars

--- a/plans/_index.md
+++ b/plans/_index.md
@@ -21,7 +21,7 @@
 | `040-goap-phase-d-039-phase-bc-completion.md` | GOAP Plan     | Complete ✅  | @scope blocks, OKLCH shadow tokens, Popover API command-palette, interpolate-size, accent-color, plan status hygiene |
 | `adr-029-android-release-signing.md`           | ADR           | Accepted ✅  | Android release signing via CI — keystore from GitHub secrets, versionCode from GITHUB_RUN_NUMBER, versionName from VERSION |
 | `041-goap-release-signing-and-plan040-completion.md` | GOAP Plan | Complete ✅ | Close Plan 040 gaps (@scope dedup, OKLCH shadow tokens) + wire release APK signing into CI |
-| `042-goap-plans-completion-sprint.md` | GOAP Plan | Active 🔄 | Close P0 plan-audit gaps: rebuild stale design-tokens.css, fix plan status headers, promote ADR-015, add SW cache TTL, wire LH CI |
+| `042-goap-plans-completion-sprint.md` | GOAP Plan | Complete ✅ | Close P0 plan-audit gaps: rebuild stale design-tokens.css, fix plan status headers, promote ADR-015, add SW cache TTL, wire LH CI |
 
 ## Archived
 
@@ -107,10 +107,10 @@ These numbered plans document the project's foundation and are considered stable
 | `036-progress-update-2026-07-18.md`                   | Progress | Complete ✅ | Swarm roundup — ADR compliance verified, compacted learnings, AGENTS.md refresh  |
 | `037-progress-update-2026-07-18.md`                   | Progress | Complete ✅ | TRIZ contradiction audit, skill registry docs, AGENTS.md skill directory refs  |
 | `041-goap-release-signing-and-plan040-completion.md`  | GOAP     | Complete ✅ | Close Plan 040 gaps + wire release APK signing into CI       |
-| `042-goap-plans-completion-sprint.md`                  | GOAP     | Active 🔄   | Close P0 plan-audit gaps: rebuild stale design-tokens.css, fix plan status headers, promote ADR-015, add SW cache TTL, wire LH CI |
+| `042-goap-plans-completion-sprint.md`                  | GOAP     | Complete ✅   | Close P0 plan-audit gaps: rebuild stale design-tokens.css, fix plan status headers, promote ADR-015, add SW cache TTL, wire LH CI |
 
 ## Quick reference: ADR numbers in use
 
 `adr-001` through `adr-029` (gaps: 017-019 reserved)
 **Next available ADR**: `adr-030`
-**Next available plan number**: `042`
+**Next available plan number**: `043`

--- a/plans/_status.json
+++ b/plans/_status.json
@@ -231,7 +231,7 @@
     },
     "042-goap-plans-completion-sprint.md": {
       "type": "goap",
-      "status": "active",
+      "status": "complete",
       "summary": "Close P0 plan-audit gaps: rebuild stale design-tokens.css, fix plan status headers, promote ADR-015, add SW cache TTL, wire LH CI"
     }
   },
@@ -266,7 +266,7 @@
   ],
   "nextAvailable": {
     "adr": "adr-030",
-    "plan": "042",
+    "plan": "043",
     "goap": "032"
   }
 }

--- a/src/sw/sw.ts
+++ b/src/sw/sw.ts
@@ -26,7 +26,7 @@ function addTimestampToResponse(response: Response): Response {
 
 function isResponseExpired(response: Response): boolean {
   const timestamp = response.headers.get('x-cache-timestamp');
-  if (!timestamp) return true;
+  if (!timestamp) return false;
   return Date.now() - Number(timestamp) > CACHE_MAX_AGE_MS;
 }
 
@@ -166,7 +166,16 @@ swSelf.addEventListener('fetch', (event: FetchEvent) => {
   ) {
     event.respondWith(
       caches.match(request).then((cachedResponse) => {
-        if (cachedResponse) return cachedResponse;
+        if (cachedResponse) {
+          if (isResponseExpired(cachedResponse)) {
+            caches
+              .open(STATIC_CACHE)
+              .then((cache) => cache.delete(request))
+              .catch(() => {});
+          } else {
+            return cachedResponse;
+          }
+        }
 
         return fetch(request).then((response) => {
           if (!response.ok) return response;

--- a/src/sw/sw.ts
+++ b/src/sw/sw.ts
@@ -11,6 +11,38 @@ import { APP } from '../config/app.config';
 
 const STATIC_CACHE = `${APP.staticCacheName}-__BUILD_TIMESTAMP__`;
 
+// Cache entry TTL: 30 days in milliseconds
+const CACHE_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000;
+
+function addTimestampToResponse(response: Response): Response {
+  const headers = new Headers(response.headers);
+  headers.set('x-cache-timestamp', Date.now().toString());
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
+function isResponseExpired(response: Response): boolean {
+  const timestamp = response.headers.get('x-cache-timestamp');
+  if (!timestamp) return true;
+  return Date.now() - Number(timestamp) > CACHE_MAX_AGE_MS;
+}
+
+async function cleanExpiredEntries(cacheName: string): Promise<void> {
+  const cache = await caches.open(cacheName);
+  const requests = await cache.keys();
+  const deletePromises: Promise<boolean>[] = [];
+  for (const request of requests) {
+    const response = await cache.match(request);
+    if (response && isResponseExpired(response)) {
+      deletePromises.push(cache.delete(request));
+    }
+  }
+  await Promise.all(deletePromises);
+}
+
 // Assets to precache (app shell)
 const PRECACHE_ASSETS = [
   '/',
@@ -41,18 +73,20 @@ swSelf.addEventListener('install', (event: ExtendableEvent) => {
 });
 
 /**
- * Activate event - clean up old caches
+ * Activate event - clean up old caches and expired entries
  * - Deletes entire caches not matching the current STATIC_CACHE name
  * - Uses build-timestamp cache naming for version-based eviction
+ * - Evicts individual entries older than 30 days (TTL-based cleanup)
  */
 swSelf.addEventListener('activate', (event: ExtendableEvent) => {
   event.waitUntil(
     caches
       .keys()
       .then((cacheNames) => {
-        return Promise.all(
-          cacheNames.filter((name) => name !== STATIC_CACHE).map((name) => caches.delete(name))
-        );
+        const deleteOldCaches = cacheNames
+          .filter((name) => name !== STATIC_CACHE)
+          .map((name) => caches.delete(name));
+        return Promise.all([...deleteOldCaches, cleanExpiredEntries(STATIC_CACHE)]);
       })
       .then(() => swSelf.clients.claim())
   );
@@ -92,10 +126,11 @@ swSelf.addEventListener('fetch', (event: FetchEvent) => {
       fetch(request)
         .then((response) => {
           const responseClone = response.clone();
+          const timestampedResponse = addTimestampToResponse(responseClone);
           caches
             .open(STATIC_CACHE)
             .then((cache) => {
-              cache.put(request, responseClone).catch(() => {});
+              cache.put(request, timestampedResponse).catch(() => {});
             })
             .catch(() => {});
           return response;
@@ -137,10 +172,11 @@ swSelf.addEventListener('fetch', (event: FetchEvent) => {
           if (!response.ok) return response;
 
           const responseClone = response.clone();
+          const timestampedResponse = addTimestampToResponse(responseClone);
           caches
             .open(STATIC_CACHE)
             .then((cache) => {
-              cache.put(request, responseClone).catch(() => {});
+              cache.put(request, timestampedResponse).catch(() => {});
             })
             .catch(() => {});
           return response;


### PR DESCRIPTION
## Summary

- Add TTL-based cache entry expiration to service worker (30-day max-age)
- Mark plan 042 complete, fix plan 040 status header
- Update all plan registries (_status.json, _index.md, README.md)
- Create progress update

## Plan 042 Task Completion

| # | Action | Status |
|---|--------|--------|
| 1 | Rebuild `public/design-tokens.css` from updated TS source | ✓ (prev commit) |
| 2 | Mark Plan 041 complete + fix Plan 040 stale header | ✓ |
| 3 | Promote ADR-015 from "Proposed" to "Accepted" | ✓ (prev commit) |
| 4 | Add TTL-based cache entry expiration to service worker | ✓ **NEW** |
| 5 | Wire Lighthouse CI into CI workflow | ✓ (prev commit) |
| 6 | Create progress update and PR | ✓ |

## Verification

- TypeScript: `tsc --noEmit` — pass
- Lint: `biome check src` — zero errors  
- Tests: 963 tests, 53 files — all pass
- Coverage: 91.64% statements, 94.08% lines
- Quality Gate: All checks passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Service worker now enforces time-based cache expiration for navigation and static assets: expired entries are automatically removed, unexpired items are served from cache, and newly fetched assets are stored with freshness metadata so users get up-to-date content with reliable cache fallbacks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/d-o-hub/do-gist-hub/pull/176?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->