### PR TITLE
feat(048): add WCAG AA contrast lint rule — plan 050 completion

### DIFF
--- a/plans/048-codebase-audit-implementation-gaps-ci-docs.md
+++ b/plans/048-codebase-audit-implementation-gaps-ci-docs.md
@@ -294,7 +294,7 @@ All 20 claimed features verified as implemented. Two minor discrepancies:
 
 | # | Action | Precondition | Effect | Cost | Status |
 |---|--------|-------------|--------|------|--------|
-| 28 | Add WCAG AA contrast lint rule for tokens | ADR-001 compliance | Automated contrast checking | M | ☐ |
+| 28 | Add WCAG AA contrast lint rule for tokens | ADR-001 compliance | Automated contrast checking | M | ✅ |
 | 29 | Remove hardcoded `rgba()` and pixel values from CSS that should use tokens | P2-9 related | Token-only CSS compliance | S | ✅ |
 | 30 | Add `.lintstagedrc.json` config for lint-staged (Biome commands) | ADR-012 compliance | Pre-commit only runs on staged files | S | ✅ |
 | 31 | Pass `Retry-After` header from rate-limiter to sync queue | ADR-014 compliance | Server-directed backoff | XS | ✅ |

--- a/scripts/check-contrast.ts
+++ b/scripts/check-contrast.ts
@@ -1,0 +1,283 @@
+#!/usr/bin/env npx tsx
+/**
+ * WCAG AA Contrast Checker for Design Tokens
+ *
+ * Verifies all foreground/background color token pairs meet:
+ *   - WCAG AA normal text: 4.5:1 minimum
+ *   - WCAG AA large text (18px+ or 14px+ bold): 3:1 minimum
+ *
+ * Sources token values directly from src/tokens/semantic/color-semantic.ts.
+ * Run: npx tsx scripts/check-contrast.ts
+ * Exit code: 0 if all pairs pass, 1 if any fail
+ */
+
+import { colorSemantic } from '../src/tokens/semantic/color-semantic';
+
+function hexToRgb(hex: string): [number, number, number] | null {
+  const clean = hex.replace('#', '');
+  if (!/^[0-9a-fA-F]{6}$/.test(clean)) {
+    return null;
+  }
+  return [
+    Number.parseInt(clean.slice(0, 2), 16),
+    Number.parseInt(clean.slice(2, 4), 16),
+    Number.parseInt(clean.slice(4, 6), 16),
+  ];
+}
+
+function srgbChannel(c: number): number {
+  const s = c / 255;
+  return s <= 0.04045 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+}
+
+function relativeLuminance(r: number, g: number, b: number): number {
+  return 0.2126 * srgbChannel(r) + 0.7152 * srgbChannel(g) + 0.0722 * srgbChannel(b);
+}
+
+function relativeLuminanceHex(hex: string): number | null {
+  const rgb = hexToRgb(hex);
+  if (!rgb) {
+    return null;
+  }
+  return relativeLuminance(...rgb);
+}
+
+function contrastRatio(fg: string, bg: string): number | null {
+  const l1 = relativeLuminanceHex(fg);
+  const l2 = relativeLuminanceHex(bg);
+  if (l1 === null || l2 === null) {
+    return null;
+  }
+  const lighter = Math.max(l1, l2);
+  const darker = Math.min(l1, l2);
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+/**
+ * Blend a semi-transparent rgba foreground with a solid background.
+ * Returns the resulting solid color as if rendered on that background.
+ */
+function blendRgbaOnHex(rgba: string, bgHex: string): string | null {
+  const rgbaMatch = rgba.match(/rgba\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*,\s*([\d.]+)\s*\)/);
+  if (!rgbaMatch) {
+    return null;
+  }
+  const rFg = Number.parseInt(rgbaMatch[1]);
+  const gFg = Number.parseInt(rgbaMatch[2]);
+  const bFg = Number.parseInt(rgbaMatch[3]);
+  const a = Number.parseFloat(rgbaMatch[4]);
+
+  const bgRgb = hexToRgb(bgHex);
+  if (!bgRgb) {
+    return null;
+  }
+
+  const r = Math.round(rFg * a + bgRgb[0] * (1 - a));
+  const g = Math.round(gFg * a + bgRgb[1] * (1 - a));
+  const b = Math.round(bFg * a + bgRgb[2] * (1 - a));
+
+  return `#${r.toString(16).padStart(2, '0')}${g.toString(16).padStart(2, '0')}${b.toString(16).padStart(2, '0')}`;
+}
+
+interface ColorPair {
+  name: string;
+  fg: string;
+  bg: string;
+  threshold: 'normal' | 'large';
+}
+
+const AA_NORMAL = 4.5;
+const AA_LARGE = 3.0;
+
+const D = colorSemantic.dark;
+const L = colorSemantic.light;
+
+const pairs: ColorPair[] = [
+  // ===== Dark Theme =====
+  // Foreground on background-primary
+  {
+    name: 'dark:foreground-primary on background-primary',
+    fg: D.foreground.primary,
+    bg: D.background.primary,
+    threshold: 'normal',
+  },
+  {
+    name: 'dark:foreground-secondary on background-primary',
+    fg: D.foreground.secondary,
+    bg: D.background.primary,
+    threshold: 'normal',
+  },
+  {
+    name: 'dark:foreground-muted on background-primary',
+    fg: D.foreground.muted,
+    bg: D.background.primary,
+    threshold: 'large',
+  },
+  // Accent on background-primary (for links, buttons)
+  {
+    name: 'dark:accent-primary on background-primary',
+    fg: D.accent.primary,
+    bg: D.background.primary,
+    threshold: 'normal',
+  },
+  {
+    name: 'dark:accent-hover on background-primary',
+    fg: D.accent.hover,
+    bg: D.background.primary,
+    threshold: 'normal',
+  },
+  // Foreground on elevated surfaces
+  {
+    name: 'dark:foreground-primary on background-secondary',
+    fg: D.foreground.primary,
+    bg: D.background.secondary,
+    threshold: 'normal',
+  },
+  {
+    name: 'dark:foreground-primary on background-tertiary',
+    fg: D.foreground.primary,
+    bg: D.background.tertiary,
+    threshold: 'normal',
+  },
+  {
+    name: 'dark:foreground-primary on background-elevated',
+    fg: D.foreground.primary,
+    bg: D.background.elevated,
+    threshold: 'normal',
+  },
+  // Status colors — fg on opaque bg (blended from transparent bg on the actual surface)
+  {
+    name: 'dark:status-success-fg on primary surface',
+    fg: D.status.success.fg,
+    bg: blendRgbaOnHex(D.status.success.bg, D.background.primary) ?? '',
+    threshold: 'normal',
+  },
+  {
+    name: 'dark:status-error-fg on primary surface',
+    fg: D.status.error.fg,
+    bg: blendRgbaOnHex(D.status.error.bg, D.background.primary) ?? '',
+    threshold: 'normal',
+  },
+  {
+    name: 'dark:status-warning-fg on primary surface',
+    fg: D.status.warning.fg,
+    bg: blendRgbaOnHex(D.status.warning.bg, D.background.primary) ?? '',
+    threshold: 'normal',
+  },
+  {
+    name: 'dark:status-info-fg on primary surface',
+    fg: D.status.info.fg,
+    bg: blendRgbaOnHex(D.status.info.bg, D.background.primary) ?? '',
+    threshold: 'normal',
+  },
+
+  // ===== Light Theme =====
+  // Foreground on background-primary
+  {
+    name: 'light:foreground-primary on background-primary',
+    fg: L.foreground.primary,
+    bg: L.background.primary,
+    threshold: 'normal',
+  },
+  {
+    name: 'light:foreground-secondary on background-primary',
+    fg: L.foreground.secondary,
+    bg: L.background.primary,
+    threshold: 'normal',
+  },
+  {
+    name: 'light:foreground-muted on background-primary',
+    fg: L.foreground.muted,
+    bg: L.background.primary,
+    threshold: 'large',
+  },
+  // Accent on background-primary
+  {
+    name: 'light:accent-primary on background-primary',
+    fg: L.accent.primary,
+    bg: L.background.primary,
+    threshold: 'normal',
+  },
+  {
+    name: 'light:accent-hover on background-primary',
+    fg: L.accent.hover,
+    bg: L.background.primary,
+    threshold: 'normal',
+  },
+  // Foreground on elevated surfaces
+  {
+    name: 'light:foreground-primary on background-secondary',
+    fg: L.foreground.primary,
+    bg: L.background.secondary,
+    threshold: 'normal',
+  },
+  {
+    name: 'light:foreground-primary on background-tertiary',
+    fg: L.foreground.primary,
+    bg: L.background.tertiary,
+    threshold: 'normal',
+  },
+  {
+    name: 'light:foreground-primary on background-elevated',
+    fg: L.foreground.primary,
+    bg: L.background.elevated,
+    threshold: 'normal',
+  },
+  // Status colors (light mode bg are opaque)
+  {
+    name: 'light:status-success-fg on status-success-bg',
+    fg: L.status.success.fg,
+    bg: L.status.success.bg,
+    threshold: 'normal',
+  },
+  {
+    name: 'light:status-error-fg on status-error-bg',
+    fg: L.status.error.fg,
+    bg: L.status.error.bg,
+    threshold: 'normal',
+  },
+  {
+    name: 'light:status-warning-fg on status-warning-bg',
+    fg: L.status.warning.fg,
+    bg: L.status.warning.bg,
+    threshold: 'normal',
+  },
+  {
+    name: 'light:status-info-fg on status-info-bg',
+    fg: L.status.info.fg,
+    bg: L.status.info.bg,
+    threshold: 'normal',
+  },
+];
+
+let failures = 0;
+let checked = 0;
+
+for (const pair of pairs) {
+  if (!pair.bg || !pair.fg) {
+    console.log(`[SKIP] ${pair.name} — could not resolve color`);
+    continue;
+  }
+
+  const ratio = contrastRatio(pair.fg, pair.bg);
+
+  if (ratio === null) {
+    console.log(`[SKIP] ${pair.name} — could not compute ratio`);
+    continue;
+  }
+
+  const minRatio = pair.threshold === 'normal' ? AA_NORMAL : AA_LARGE;
+  checked++;
+
+  if (ratio >= minRatio) {
+    console.log(`[PASS] ${pair.name} — ${ratio.toFixed(2)}:1`);
+  } else {
+    console.log(`[FAIL] ${pair.name} — ${ratio.toFixed(2)}:1 (need ${minRatio.toFixed(1)}:1)`);
+    failures++;
+  }
+}
+
+console.log(`\n${checked} checked, ${failures} failed`);
+if (failures > 0) {
+  process.exit(1);
+}

--- a/scripts/check-contrast.ts
+++ b/scripts/check-contrast.ts
@@ -62,10 +62,19 @@ function blendRgbaOnHex(rgba: string, bgHex: string): string | null {
   if (!rgbaMatch) {
     return null;
   }
-  const rFg = Number.parseInt(rgbaMatch[1]);
-  const gFg = Number.parseInt(rgbaMatch[2]);
-  const bFg = Number.parseInt(rgbaMatch[3]);
+  const rFg = Number.parseInt(rgbaMatch[1], 10);
+  const gFg = Number.parseInt(rgbaMatch[2], 10);
+  const bFg = Number.parseInt(rgbaMatch[3], 10);
   const a = Number.parseFloat(rgbaMatch[4]);
+
+  if (
+    !Number.isInteger(rFg) || rFg < 0 || rFg > 255 ||
+    !Number.isInteger(gFg) || gFg < 0 || gFg > 255 ||
+    !Number.isInteger(bFg) || bFg < 0 || bFg > 255 ||
+    Number.isNaN(a) || a < 0 || a > 1
+  ) {
+    return null;
+  }
 
   const bgRgb = hexToRgb(bgHex);
   if (!bgRgb) {
@@ -255,14 +264,16 @@ let checked = 0;
 
 for (const pair of pairs) {
   if (!pair.bg || !pair.fg) {
-    console.log(`[SKIP] ${pair.name} — could not resolve color`);
+    console.error(`[FAIL] ${pair.name} — could not resolve color (fg=${pair.fg}, bg=${pair.bg})`);
+    failures++;
     continue;
   }
 
   const ratio = contrastRatio(pair.fg, pair.bg);
 
   if (ratio === null) {
-    console.log(`[SKIP] ${pair.name} — could not compute ratio`);
+    console.error(`[FAIL] ${pair.name} — could not compute ratio (fg=${pair.fg}, bg=${pair.bg})`);
+    failures++;
     continue;
   }
 

--- a/scripts/quality_gate.sh
+++ b/scripts/quality_gate.sh
@@ -53,6 +53,11 @@ if [[ -f "$ROOT_DIR/scripts/check-adr-compliance.sh" ]]; then
   echo "✓ ADR compliance check passed"
 fi
 
+# WCAG AA contrast check (from plan 048 Action 28)
+echo "→ WCAG AA contrast check..."
+npx tsx "$ROOT_DIR/scripts/check-contrast.ts" || { echo "✗ WCAG AA contrast check failed"; exit 1; }
+echo "✓ WCAG AA contrast check passed"
+
 # Plan numbering consistency (from plan 038 E4)
 if [[ -f "$ROOT_DIR/scripts/check-plan-numbering.sh" ]]; then
   echo "→ Plan numbering check..."

--- a/src/tokens/semantic/color-semantic.ts
+++ b/src/tokens/semantic/color-semantic.ts
@@ -15,15 +15,15 @@ export const colorSemantic = {
     foreground: {
       primary: '#0F172A',
       secondary: '#475569',
-      muted: '#94A3B8',
+      muted: '#64748B',
       inverse: '#FFFFFF',
     },
     accent: {
-      primary: '#3B82F6',
-      hover: '#2563EB',
-      active: '#1D4ED8',
-      subtle: 'rgba(59, 130, 246, 0.08)',
-      glow: 'rgba(59, 130, 246, 0.25)',
+      primary: '#2563EB',
+      hover: '#1D4ED8',
+      active: '#1E40AF',
+      subtle: 'rgba(37, 99, 235, 0.08)',
+      glow: 'rgba(37, 99, 235, 0.25)',
     },
     border: {
       default: '#E2E8F0',
@@ -34,12 +34,12 @@ export const colorSemantic = {
       success: { bg: '#F0FDF4', fg: '#15803D', border: '#86EFAC' },
       error: { bg: '#FEF2F2', fg: '#B91C1C', border: '#FCA5A5' },
       warning: { bg: '#FFFBEB', fg: '#B45309', border: '#FDE047' },
-      info: { bg: '#EFF6FF', fg: '#1D4ED8', border: '#93C5FD' },
+      info: { bg: '#EFF6FF', fg: '#2563EB', border: '#93C5FD' },
     },
     interactive: {
       hover: '#F1F5F9',
       active: '#E2E8F0',
-      focus: 'rgba(59, 130, 246, 0.15)',
+      focus: 'rgba(37, 99, 235, 0.15)',
     },
   },
   dark: {

--- a/tests/unit/__snapshots__/css-variables.test.ts.snap
+++ b/tests/unit/__snapshots__/css-variables.test.ts.snap
@@ -278,14 +278,14 @@ exports[`generateCSSVariables > matches the full CSS output snapshot 1`] = `
 
   --color-foreground-primary: #0F172A;
   --color-foreground-secondary: #475569;
-  --color-foreground-muted: #94A3B8;
+  --color-foreground-muted: #64748B;
   --color-foreground-inverse: #FFFFFF;
 
-  --color-accent-primary: #3B82F6;
-  --color-accent-hover: #2563EB;
-  --color-accent-active: #1D4ED8;
-  --color-accent-subtle: rgba(59, 130, 246, 0.08);
-  --color-accent-glow: rgba(59, 130, 246, 0.25);
+  --color-accent-primary: #2563EB;
+  --color-accent-hover: #1D4ED8;
+  --color-accent-active: #1E40AF;
+  --color-accent-subtle: rgba(37, 99, 235, 0.08);
+  --color-accent-glow: rgba(37, 99, 235, 0.25);
 
   --color-border-default: #E2E8F0;
   --color-border-emphasis: #CBD5E1;
@@ -304,12 +304,12 @@ exports[`generateCSSVariables > matches the full CSS output snapshot 1`] = `
   --color-status-warning-border: #FDE047;
 
   --color-status-info-bg: #EFF6FF;
-  --color-status-info-fg: #1D4ED8;
+  --color-status-info-fg: #2563EB;
   --color-status-info-border: #93C5FD;
 
   --color-interactive-hover: #F1F5F9;
   --color-interactive-active: #E2E8F0;
-  --color-interactive-focus: rgba(59, 130, 246, 0.15);
+  --color-interactive-focus: rgba(37, 99, 235, 0.15);
 
   /* Light mode shadows */
   --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.05);


### PR DESCRIPTION
Implements plan 050 (v2) — the last missing item from the plan 048 deep audit.

## Changes

### Action 28: WCAG AA Contrast Lint Rule (plan 048 GOAP)
- **New**: `scripts/check-contrast.ts` — automated contrast checker that validates all 24 foreground/background token pairs against WCAG AA thresholds (4.5:1 normal, 3:1 large). Blends transparent rgba backgrounds against their actual surface for accurate measurement. Sources values directly from `src/tokens/semantic/color-semantic.ts`.
- **Wired**: Into `quality_gate.sh` as an ADR-001 compliance gate.
- **Fixed**: Light mode `accent-primary` → `#2563EB` (blue-600), `foreground-muted` → `#64748B` (slate-500) to meet WCAG AA on `#FAFAFA` background.
- **Updated**: Light mode `info-fg`, `interactive-focus` to match new accent value.
- **Marked**: Plan 048 action 28 complete. All 42 GOAP actions now done.

### Verification
- [x] TypeScript: no errors
- [x] Biome lint: zero violations
- [x] Unit tests: 985 passing (snapshot updated)
- [x] Quality gate: all checks passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated light theme semantic colors: muted foreground, new blue accent palette (primary/hover/active/subtle/glow), status info shades, and interactive focus for improved visual consistency.

* **Chores**
  * Added an automated WCAG AA contrast validation check that reports pass/fail and is enforced in quality gates, failing the pipeline when contrast requirements are not met.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/d-o-hub/do-gist-hub/pull/194?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->