### PR TITLE
feat: implement remaining gaps — PAT telemetry, auth diagnostics UI, SW API cache

### DIFF
--- a/src/routes/settings.ts
+++ b/src/routes/settings.ts
@@ -12,7 +12,11 @@ import { lifecycle } from '../services/lifecycle';
 import networkMonitor from '../services/network/offline-monitor';
 import { redactToken, sanitizeHtml } from '../services/security';
 import { safeError } from '../services/security/logger';
-import { recordAuthCompleted } from '../services/telemetry/auth-telemetry';
+import {
+  readTelemetry,
+  recordAuthCompleted,
+  recordAuthMethod,
+} from '../services/telemetry/auth-telemetry';
 import gistStore from '../stores/gist-store';
 import { getThemePreference, initTheme } from '../tokens/design-tokens';
 import { showConfirmDialog } from '../utils/dialog';
@@ -111,7 +115,7 @@ export async function render(
   `;
 
   await loadTokenInfo(container);
-  loadDiagnostics(container);
+  await loadDiagnostics(container);
   loadAccentHue(container);
   bindEvents(container, signal);
 }
@@ -146,9 +150,9 @@ async function loadTokenInfo(container: HTMLElement): Promise<void> {
 }
 
 /**
- * Render diagnostics info (online status, gist count, current theme) into the settings UI.
+ * Render diagnostics info (online status, gist count, current theme, auth telemetry) into the settings UI.
  */
-function loadDiagnostics(container: HTMLElement): void {
+async function loadDiagnostics(container: HTMLElement): Promise<void> {
   const diagnosticsContainer = container.querySelector('#diagnostics-info');
   if (!diagnosticsContainer) return;
 
@@ -156,13 +160,25 @@ function loadDiagnostics(container: HTMLElement): void {
     online: networkMonitor.isOnline(),
     gistsCount: gistStore.getGists().length,
     theme: document.documentElement.getAttribute('data-theme'),
+    telemetry: await (async () => {
+      try {
+        return await readTelemetry();
+      } catch {
+        return null;
+      }
+    })(),
   };
+
+  const telemetryHtml = info.telemetry
+    ? `<p>Auth: ${info.telemetry.patCount} PAT, ${info.telemetry.deviceFlowCount} Device Flow</p>`
+    : '';
 
   diagnosticsContainer.innerHTML = `
     <div class="diagnostics-content micro-label">
       <p>Online: ${info.online ? 'Yes' : 'No'}</p>
       <p>Gists: ${info.gistsCount}</p>
       <p>Theme: ${sanitizeHtml(info.theme || 'auto')}</p>
+      ${telemetryHtml}
     </div>
   `;
 }
@@ -198,6 +214,7 @@ function bindEvents(container: HTMLElement, signal: AbortSignal): void {
             const result = await saveToken(input.value);
             if (result.success) {
               toast.success('TOKEN SAVED');
+              await recordAuthMethod('pat');
               await recordAuthCompleted();
               await loadTokenInfo(container);
               input.value = '';
@@ -305,14 +322,14 @@ function bindEvents(container: HTMLElement, signal: AbortSignal): void {
             select.value = effective;
           }
           if (signal.aborted) return;
-          loadDiagnostics(container);
+          await loadDiagnostics(container);
         })();
         return;
       } else {
         localStorage.setItem('theme-preference', theme);
         initTheme();
       }
-      loadDiagnostics(container);
+      void loadDiagnostics(container);
     },
     { signal }
   );

--- a/src/routes/settings.ts
+++ b/src/routes/settings.ts
@@ -169,18 +169,19 @@ async function loadDiagnostics(container: HTMLElement): Promise<void> {
     })(),
   };
 
-  const telemetryHtml = info.telemetry
-    ? `<p>Auth: ${info.telemetry.patCount} PAT, ${info.telemetry.deviceFlowCount} Device Flow</p>`
-    : '';
-
   diagnosticsContainer.innerHTML = `
     <div class="diagnostics-content micro-label">
       <p>Online: ${info.online ? 'Yes' : 'No'}</p>
       <p>Gists: ${info.gistsCount}</p>
       <p>Theme: ${sanitizeHtml(info.theme || 'auto')}</p>
-      ${telemetryHtml}
     </div>
   `;
+
+  if (info.telemetry) {
+    const telemetryRow = document.createElement('p');
+    telemetryRow.textContent = `Auth: ${info.telemetry.patCount} PAT, ${info.telemetry.deviceFlowCount} Device Flow`;
+    diagnosticsContainer.querySelector('.diagnostics-content')?.appendChild(telemetryRow);
+  }
 }
 
 /**
@@ -214,8 +215,8 @@ function bindEvents(container: HTMLElement, signal: AbortSignal): void {
             const result = await saveToken(input.value);
             if (result.success) {
               toast.success('TOKEN SAVED');
-              await recordAuthMethod('pat');
-              await recordAuthCompleted();
+              void recordAuthMethod('pat').catch(() => {});
+              void recordAuthCompleted().catch(() => {});
               await loadTokenInfo(container);
               input.value = '';
             } else {

--- a/src/services/telemetry/auth-telemetry.ts
+++ b/src/services/telemetry/auth-telemetry.ts
@@ -30,6 +30,10 @@ function createDefaultTelemetry(): AuthTelemetryData {
   };
 }
 
+/**
+ * Read the current auth telemetry data from IndexedDB.
+ * Returns a default structure if no data has been persisted yet.
+ */
 export async function readTelemetry(): Promise<AuthTelemetryData> {
   const data = await getMetadata<AuthTelemetryData>(TELEMETRY_KEY);
   return data ?? createDefaultTelemetry();

--- a/src/services/telemetry/auth-telemetry.ts
+++ b/src/services/telemetry/auth-telemetry.ts
@@ -30,7 +30,7 @@ function createDefaultTelemetry(): AuthTelemetryData {
   };
 }
 
-async function readTelemetry(): Promise<AuthTelemetryData> {
+export async function readTelemetry(): Promise<AuthTelemetryData> {
   const data = await getMetadata<AuthTelemetryData>(TELEMETRY_KEY);
   return data ?? createDefaultTelemetry();
 }

--- a/src/sw/sw.ts
+++ b/src/sw/sw.ts
@@ -86,10 +86,15 @@ swSelf.addEventListener('activate', (event: ExtendableEvent) => {
     caches
       .keys()
       .then((cacheNames) => {
+        const preserve = [STATIC_CACHE, APP.apiCacheName];
         const deleteOldCaches = cacheNames
-          .filter((name) => name !== STATIC_CACHE)
+          .filter((name) => !preserve.includes(name))
           .map((name) => caches.delete(name));
-        return Promise.all([...deleteOldCaches, cleanExpiredEntries(STATIC_CACHE)]);
+        return Promise.all([
+          ...deleteOldCaches,
+          cleanExpiredEntries(STATIC_CACHE),
+          cleanExpiredEntries(APP.apiCacheName),
+        ]);
       })
       .then(() => swSelf.clients.claim())
   );
@@ -155,18 +160,21 @@ swSelf.addEventListener('fetch', (event: FetchEvent) => {
   }
 
   // GitHub API requests — network first with dedicated API cache (ADR-010)
+  // Only cache GET requests with successful responses
   if (url.origin === 'https://api.github.com') {
     event.respondWith(
       fetch(request)
         .then((response) => {
-          const responseClone = response.clone();
-          const timestampedResponse = addTimestampToResponse(responseClone);
-          caches
-            .open(APP.apiCacheName)
-            .then((cache) => {
-              cache.put(request, timestampedResponse).catch(() => {});
-            })
-            .catch(() => {});
+          if (request.method === 'GET' && response.ok) {
+            const responseClone = response.clone();
+            const timestampedResponse = addTimestampToResponse(responseClone);
+            caches
+              .open(APP.apiCacheName)
+              .then((cache) => {
+                cache.put(request, timestampedResponse).catch(() => {});
+              })
+              .catch(() => {});
+          }
           return response;
         })
         .catch(async () => {

--- a/src/sw/sw.ts
+++ b/src/sw/sw.ts
@@ -154,9 +154,32 @@ swSelf.addEventListener('fetch', (event: FetchEvent) => {
     return;
   }
 
-  // GitHub API requests — never cache; always go to network
+  // GitHub API requests — network first with dedicated API cache (ADR-010)
   if (url.origin === 'https://api.github.com') {
-    event.respondWith(fetch(request));
+    event.respondWith(
+      fetch(request)
+        .then((response) => {
+          const responseClone = response.clone();
+          const timestampedResponse = addTimestampToResponse(responseClone);
+          caches
+            .open(APP.apiCacheName)
+            .then((cache) => {
+              cache.put(request, timestampedResponse).catch(() => {});
+            })
+            .catch(() => {});
+          return response;
+        })
+        .catch(async () => {
+          const cached = await caches.match(request);
+          return (
+            cached ||
+            new Response(JSON.stringify({ error: 'offline' }), {
+              status: 503,
+              headers: { 'Content-Type': 'application/json' },
+            })
+          );
+        })
+    );
     return;
   }
 


### PR DESCRIPTION
## Summary

Implements the remaining implementation gaps identified across plan audits:

### Changes

1. **PAT telemetry** (src/routes/settings.ts): Wire `recordAuthMethod('pat')` on PAT save — was only recording device-flow authentications
2. **Auth diagnostics UI** (src/routes/settings.ts, auth-telemetry.ts): Export `readTelemetry()` and display PAT vs Device Flow auth method counts in the Settings → Data & Diagnostics section
3. **SW API cache** (src/sw/sw.ts): Implement network-first GitHub API caching using the existing `apiCacheName` config (was previously unused — ADR-010 gap). Provides offline fallback with 503 JSON error response

### Verification

- All 985 unit tests pass (54 test files)
- TypeScript strict, Biome lint, format:check — 0 errors  
- Full quality gate green
- WCAG AA contrast: 24/24 pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API requests now use network-first caching with a dedicated offline cache and graceful fallback (returns 503 JSON when offline).
  * Authentication method selection is now recorded for telemetry.

* **Improvements**
  * Diagnostics loading is now asynchronous for smoother UI and during theme changes.
  * Telemetry reading has better error handling and is conditionally shown in diagnostics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/d-o-hub/do-gist-hub/pull/197?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->