### PR TITLE
docs(plans): add impact analysis for upstream template sync

### DIFF
--- a/plans/054-upstream-template-impact-analysis.md
+++ b/plans/054-upstream-template-impact-analysis.md
@@ -1,0 +1,89 @@
+> **Status**: Active
+> **Type**: Analysis
+> **Created**: 2026-05-21
+> **Updated**: 2026-05-21
+> **Owner**: agent
+> **Related**: adr-015, 019-swarm-analysis-codebase-improvements.md, 038-codebase-audit-recommendations-2026-05-16.md
+
+# Impact Analysis: Upstream Template Synchronization
+
+## Executive Summary
+
+The `d.o. Gist Hub` repository was bootstrapped from the `github-template-ai-agents` template. Since our last synchronization efforts (tracked in ADR-015, Plan 019, and Plan 038), the upstream template has advanced significantly to version `v0.2.9`. This document analyzes the delta between our current state and the upstream template's state, evaluating the impact on our AI coding workflows, documentation standards, and CI/CD resilience.
+
+## 1. Delta Analysis
+
+### 1.1 New and Modified Agent Skills
+The upstream template `.agents/skills/` directory contains numerous high-value skills not present in our codebase:
+
+*   `jules-delegator`: Facilitates specialized task delegation.
+*   `anti-ai-slop`: Enforces concise, high-quality AI outputs.
+*   `code-review-assistant`: Automates deep code review patterns.
+*   `secure-invite-and-access`: Standardizes authentication and authorization patterns.
+*   `github-pr-sentinel`: Automates PR review checks and balances.
+*   `web-search-researcher`: Enables robust web-based research strategies.
+*   `do-web-doc-resolver`: Provides URL-to-markdown context resolution.
+*   `turso-db`: Reference skill for edge database integration.
+*   `goap-agent`: Formalizes Goal-Oriented Action Planning for multi-agent tasks.
+
+### 1.2 Documentation (`agents-docs/`)
+The upstream template has dramatically expanded its conceptual and reference documentation to enforce strict boundaries and self-learning loops:
+
+*   `self-learning-rules.md`
+*   `domain-rules.md`
+*   `autonomous-optimization.md`
+*   `ci-maintenance.md`
+*   Extensive `.md` files detailing workflow (`WORKFLOW.md`), references (`skills-reference.md`), and issue resolution (`CHANGES_THREAD.md`).
+
+### 1.3 Scripts and Security Hardening
+Recent commits in the upstream template demonstrate a massive focus on shell script security and utility scripts:
+
+*   **Security Fixes**: Hardening of all utility scripts against option and structural injection.
+*   **Evaluation and Validation**: Extensive `eval-skills.sh`, `run-evals.py`, and python-based validation executors (`lib/eval_executors.py`, `lib/eval_types.py`).
+*   **Automation Utilities**: `bump_patch_version.sh`, `generate-available-skills.py`, `install-git-hooks.sh`.
+*   **Command Checking**: `verify-commands.sh`, `benchmark-command-verify.sh`.
+
+### 1.4 Workflows (`.github/workflows/`)
+The upstream template features several new automation paths:
+
+*   `auto-resolve-comments.yml`
+*   `close-resolved-issues.yml`
+*   `dedup-issues.yml`
+*   `knowledge-cleanup.yml`
+
+## 2. Impact on `d.o. Gist Hub` Codebase
+
+Integrating these changes will profoundly impact how we work in this repository.
+
+### Positive Impacts
+
+1.  **Enhanced Autonomous Workflow**: Skills like `jules-delegator` and `goap-agent` will allow AI agents to plan and execute tasks with less human intervention and higher success rates.
+2.  **Increased Code Quality**: The `anti-ai-slop` and `code-review-assistant` skills enforce human-readable, concise code, preventing the degradation often caused by unchecked AI generation.
+3.  **Advanced Problem Solving**: Incorporating web-search and documentation resolution (`do-web-doc-resolver`) will allow agents to dynamically pull the latest Vite, Capacitor, or Playwright docs instead of relying on stale pre-training data.
+4.  **Strengthened CI/CD Security**: Syncing the hardened bash scripts removes latent injection vulnerabilities from our local hooks and CI pipeline tools.
+
+### Required Adaptations (The "Cost" of Syncing)
+
+1.  **Documentation Overhead**: We must port and adapt the new `agents-docs/` concepts to fit our specific PWA/Android/Gist domain, meaning `domain-rules.md` needs customization.
+2.  **Script Validation Overhaul**: The upstream template migrated heavily towards Python-based validation (`eval_executors.py`, `validate_gemini_toml.py`). Our project currently standardizes on Node.js/Bash. We must decide whether to adopt Python as a build dependency or rewrite these validations in Node.js/TypeScript.
+
+## 3. Recommended Adaptation Roadmap (GOAP)
+
+We recommend a phased approach to adopting the `v0.2.9` template updates.
+
+### Phase A: Security & Script Hardening (P0)
+*   **Action**: Port injection fixes from upstream shell scripts to our local equivalents (`quality_gate.sh`, `pre-commit-hook.sh`, `validate-skills.sh`).
+*   **Benefit**: Immediate security posture improvement.
+
+### Phase B: High-Value Workflow Skills (P1)
+*   **Action**: Cherry-pick critical workflow skills into `.agents/skills/`.
+    *   Target: `anti-ai-slop`, `jules-delegator`, `goap-agent`, `web-search-researcher`, `do-web-doc-resolver`, `github-pr-sentinel`.
+*   **Action**: Sync `EVALS_README.md` and related evaluation architectures to maintain skill quality.
+
+### Phase C: Autonomous Documentation & CI (P2)
+*   **Action**: Port relevant `agents-docs/` (e.g., `autonomous-optimization.md`, `self-learning-rules.md`) and adapt them to our TRIZ/Sentinel framework.
+*   **Action**: Integrate issue-management actions (`auto-resolve-comments.yml`, `dedup-issues.yml`) to reduce repository noise.
+
+## 4. Next Steps
+1.  Approve this impact analysis.
+2.  Create a separate plan (e.g., `055-goap-upstream-sync-phase-a.md`) to begin executing the script hardening and evaluation framework porting.

--- a/plans/README.md
+++ b/plans/README.md
@@ -36,7 +36,7 @@ plans/
 ## Naming conventions
 
 - Numbers zero-padded to 3 digits: `000`, `001`, `002`
-- **Next available plan number**: `053`
+- **Next available plan number**: `055`
 - **Next available ADR number**: `adr-031`
 - Dates: ISO 8601 `YYYY-MM-DD`
 - Slugs: lowercase kebab-case, max 40 chars

--- a/plans/_index.md
+++ b/plans/_index.md
@@ -122,4 +122,4 @@ These numbered plans document the project's foundation and are considered stable
 
 `adr-001` through `adr-030` (gaps: 017-019 reserved)
 **Next available ADR**: `adr-031`
-**Next available plan number**: `053`
+**Next available plan number**: `055`

--- a/plans/_index.md
+++ b/plans/_index.md
@@ -117,6 +117,7 @@ These numbered plans document the project's foundation and are considered stable
 | `042-goap-plans-completion-sprint.md`                  | GOAP     | Complete ✅   | Close P0 plan-audit gaps: rebuild stale design-tokens.css, fix plan status headers, promote ADR-015, add SW cache TTL, wire LH CI |
 | `049-progress-update-2026-05-19-plan048-completion.md` | Progress | Complete ✅   | Progress update for plan 048 completion |
 | `051-progress-update-2026-05-20-tdz-circular-dep-fix.md` | Progress | Complete ✅ | Diagnosed and fixed circular dependency TDZ ReferenceError (db.ts ↔ logger.ts) |
+| `054-upstream-template-impact-analysis.md`           | Analysis      | Active ⏳ | Analysis of gaps between upstream github-template-ai-agents v0.2.9 and current repo state |
 
 ## Quick reference: ADR numbers in use
 

--- a/plans/_status.json
+++ b/plans/_status.json
@@ -119,7 +119,7 @@
     "adr-022-ambient-light-extension.md": {
       "type": "adr",
       "status": "complete",
-      "summary": "Ambient light sensor theming \u2014 implemented in Phase C (029); sensor, permission flow, lifecycle, settings UI, tests"
+      "summary": "Ambient light sensor theming — implemented in Phase C (029); sensor, permission flow, lifecycle, settings UI, tests"
     },
     "adr-026-phase-a-modernization-goap.md": {
       "type": "adr",
@@ -209,12 +209,12 @@
     "adr-029-android-release-signing.md": {
       "type": "adr",
       "status": "accepted",
-      "summary": "Android release signing via CI \u2014 keystore from GitHub secrets, versionCode from GITHUB_RUN_NUMBER, versionName from VERSION file"
+      "summary": "Android release signing via CI — keystore from GitHub secrets, versionCode from GITHUB_RUN_NUMBER, versionName from VERSION file"
     },
     "adr-030-github-pages-deployment.md": {
       "type": "adr",
       "status": "proposed",
-      "summary": "GitHub Pages deployment \u2014 base path, auth proxy CORS, SW path fixes for subpath hosting"
+      "summary": "GitHub Pages deployment — base path, auth proxy CORS, SW path fixes for subpath hosting"
     },
     "041-goap-release-signing-and-plan040-completion.md": {
       "type": "goap",
@@ -298,7 +298,12 @@
   ],
   "nextAvailable": {
     "adr": "adr-031",
-    "plan": "053",
+    "plan": "055",
     "goap": "032"
+  },
+  "054-upstream-template-impact-analysis.md": {
+    "type": "analysis",
+    "status": "active",
+    "summary": "Analysis of gaps between upstream github-template-ai-agents v0.2.9 and current repo state"
   }
 }

--- a/pr_body.txt
+++ b/pr_body.txt
@@ -1,0 +1,10 @@
+This PR introduces an impact analysis documenting the differences between our codebase and the latest version (`v0.2.9`) of the upstream `github-template-ai-agents` template.
+
+### Changes
+*   Created `plans/054-upstream-template-impact-analysis.md` outlining new skills, scripts, and documentation available upstream.
+*   Added a phased GOAP roadmap detailing how we should adopt security script hardening, workflow skills, and documentation.
+*   Updated `plans/README.md`, `plans/_index.md`, and `plans/_status.json` with the new plan and incremented the next available plan number to `055`.
+
+### Verification
+*   `./scripts/quality_gate.sh` and `npm run check` passed locally.
+*   Plan numbering compliance check verified successfully.


### PR DESCRIPTION
This PR introduces an impact analysis documenting the differences between our codebase and the latest version (`v0.2.9`) of the upstream `github-template-ai-agents` template.

### Changes
*   Created `plans/054-upstream-template-impact-analysis.md` outlining new skills, scripts, and documentation available upstream.
*   Added a phased GOAP roadmap detailing how we should adopt security script hardening, workflow skills, and documentation.
*   Updated `plans/README.md`, `plans/_index.md`, and `plans/_status.json` with the new plan and incremented the next available plan number to `055`.

### Verification
*   `./scripts/quality_gate.sh` and `npm run check` passed locally.
*   Plan numbering compliance check verified successfully.

---
*PR created automatically by Jules for task [12093836804457689640](https://jules.google.com/task/12093836804457689640) started by @d-o-hub*