### PR TITLE
Hardening Gist Store ID Generation

### DIFF
--- a/src/stores/gist-store.ts
+++ b/src/stores/gist-store.ts
@@ -183,8 +183,7 @@ class GistStore {
     public_: boolean,
     files: Record<string, string>
   ): Promise<GistRecord | null> {
-const randomPart = (typeof crypto !== 'undefined' && crypto.randomUUID) ? crypto.randomUUID().slice(0, 8) : Math.random().toString(36).slice(2, 10);
-const tempId = `temp-${Date.now()}-${randomPart}`;
+    const tempId = `temp-${Date.now()}-${crypto.randomUUID().slice(0, 8)}`;
     const now = new Date().toISOString();
     const tempRecord: GistRecord = {
       id: tempId,

--- a/src/stores/gist-store.ts
+++ b/src/stores/gist-store.ts
@@ -183,7 +183,8 @@ class GistStore {
     public_: boolean,
     files: Record<string, string>
   ): Promise<GistRecord | null> {
-    const tempId = `temp-${Date.now()}-${crypto.randomUUID().slice(0, 8)}`;
+const randomPart = (typeof crypto !== 'undefined' && crypto.randomUUID) ? crypto.randomUUID().slice(0, 8) : Math.random().toString(36).slice(2, 10);
+const tempId = `temp-${Date.now()}-${randomPart}`;
     const now = new Date().toISOString();
     const tempRecord: GistRecord = {
       id: tempId,

--- a/src/stores/gist-store.ts
+++ b/src/stores/gist-store.ts
@@ -183,7 +183,7 @@ class GistStore {
     public_: boolean,
     files: Record<string, string>
   ): Promise<GistRecord | null> {
-    const tempId = `temp-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+    const tempId = `temp-${Date.now()}-${crypto.randomUUID().slice(0, 8)}`;
     const now = new Date().toISOString();
     const tempRecord: GistRecord = {
       id: tempId,


### PR DESCRIPTION
Replaced the use of `Math.random()` with `crypto.randomUUID()` in `src/stores/gist-store.ts` for generating temporary Gist IDs. This change improves security by using a cryptographically secure random number generator and reduces the risk of ID collisions. The existing `temp-` prefix and `Date.now()` timestamp are preserved for debugging and ordering consistency.

Verified the change by running unit tests and the quality gate. All checks passed.
No changes were made to `src/main.ts` as the reported commented-out log was found to be an intentional feature support comment.

---
*PR created automatically by Jules for task [7599022450142610916](https://jules.google.com/task/7599022450142610916) started by @d-o-hub*