### PR TITLE
🎨 Palette: improve accessibility for file tabs and search input

### DIFF
--- a/src/components/gist-detail.ts
+++ b/src/components/gist-detail.ts
@@ -41,7 +41,7 @@ export function renderGistDetail(gist: GistRecord): string {
       ${Object.entries(gist.files)
         .map(
           ([key, file], index) => `
-        <button class="chip file-tab ${index === 0 ? 'active' : ''}" data-file-key="${sanitizeHtml(key)}" id="tab-${index}" role="tab" aria-selected="${index === 0}" aria-controls="file-content-area">
+        <button class="chip file-tab ${index === 0 ? 'active' : ''}" data-file-key="${sanitizeHtml(key)}" id="tab-${index}" role="tab" aria-selected="${index === 0}" aria-controls="file-content-area" tabindex="${index === 0 ? '0' : '-1'}">
           ${sanitizeHtml(file.filename.toUpperCase())}
         </button>
       `
@@ -147,7 +147,7 @@ export function renderRevisions(gistId: string, revisions: GistRevision[]): stri
   return `
     <div class="revisions-list" data-gist-id="${sanitizeHtml(gistId)}">
       <header class="detail-header">
-        <button class="btn btn-ghost" id="gist-back-btn">← Back</button>
+        <button class="btn btn-ghost" id="gist-back-btn" aria-label="Go back">← Back</button>
         <h1 class="detail-title">Revisions (${revisions.length})</h1>
       </header>
       <div class="revisions-container">${revisionsHtml}</div>
@@ -220,6 +220,42 @@ export function bindDetailEvents(
 
   // File Tabs
   const tabs = container.querySelectorAll('.file-tab');
+  const tabList = container.querySelector('.file-tabs');
+
+  if (tabList) {
+    tabList.addEventListener(
+      'keydown',
+      (e) => {
+        const keyboardEvent = e as KeyboardEvent;
+        const currentTab = document.activeElement as HTMLElement;
+        if (!currentTab?.classList.contains('file-tab')) return;
+
+        const tabsArray = Array.from(tabs) as HTMLElement[];
+        const index = tabsArray.indexOf(currentTab);
+
+        let nextIndex = -1;
+        if (keyboardEvent.key === 'ArrowRight') {
+          nextIndex = (index + 1) % tabsArray.length;
+        } else if (keyboardEvent.key === 'ArrowLeft') {
+          nextIndex = (index - 1 + tabsArray.length) % tabsArray.length;
+        } else if (keyboardEvent.key === 'Home') {
+          nextIndex = 0;
+        } else if (keyboardEvent.key === 'End') {
+          nextIndex = tabsArray.length - 1;
+        }
+
+        const nextTab =
+          nextIndex !== -1 ? (tabsArray[nextIndex] as HTMLElement | undefined) : undefined;
+        if (nextTab) {
+          e.preventDefault();
+          nextTab.focus();
+          nextTab.click();
+        }
+      },
+      { signal }
+    );
+  }
+
   tabs.forEach((tab) => {
     tab.addEventListener(
       'click',
@@ -231,9 +267,11 @@ export function bindDetailEvents(
         tabs.forEach((t) => {
           t.classList.remove('active');
           t.setAttribute('aria-selected', 'false');
+          t.setAttribute('tabindex', '-1');
         });
         tab.classList.add('active');
         tab.setAttribute('aria-selected', 'true');
+        tab.setAttribute('tabindex', '0');
 
         // Update content
         void (async () => {

--- a/src/components/gist-detail.ts
+++ b/src/components/gist-detail.ts
@@ -228,7 +228,7 @@ export function bindDetailEvents(
       (e) => {
         const keyboardEvent = e as KeyboardEvent;
         const currentTab = document.activeElement as HTMLElement;
-        if (!currentTab?.classList.contains('file-tab')) return;
+        if (!currentTab.classList.contains('file-tab')) return;
 
         const tabsArray = Array.from(tabs) as HTMLElement[];
         const index = tabsArray.indexOf(currentTab);

--- a/src/routes/home.ts
+++ b/src/routes/home.ts
@@ -43,7 +43,7 @@ export function render(container: HTMLElement, params?: Record<string, string>):
     return `
       <div class="route-home">
         <div class="search-container">
-          <input type="text" id="gist-search" class="search-input" placeholder="Search gists..." value="${sanitizeHtml(query)}">
+          <input type="text" id="gist-search" class="search-input" placeholder="Search gists..." value="${sanitizeHtml(query)}" aria-label="Search gists">
         </div>
         <div class="filter-header flex-between mb-4">
             <div class="filter-buttons filter-chips">

--- a/tests/unit/gist-detail.test.ts
+++ b/tests/unit/gist-detail.test.ts
@@ -173,6 +173,7 @@ describe('GistDetail', () => {
       const html = renderRevisions('gist-1', revisions);
       expect(html).toContain('Revisions (2)');
       expect(html).toContain('gist-back-btn');
+      expect(html).toContain('aria-label="Go back"');
       expect(html).toContain('data-action="view-revision"');
     });
 
@@ -406,6 +407,81 @@ describe('GistDetail', () => {
       expect(secondTab.classList.contains('active')).toBe(true);
       expect(secondTab.getAttribute('aria-selected')).toBe('true');
       expect(container.querySelector('#tab-0')?.getAttribute('aria-selected')).toBe('false');
+    });
+
+    it('implements roving tabindex for file tabs', async () => {
+      const gistStoreModule = await import('../../src/stores/gist-store');
+      vi.mocked(gistStoreModule.default.getGist).mockReturnValue({
+        id: 'gist-1',
+        files: { 'a.ts': {}, 'b.ts': {} },
+      } as any);
+
+      bindDetailEvents(container, { onBack, onEdit, onViewRevision });
+
+      const tab0 = container.querySelector('#tab-0') as HTMLElement;
+      const tab1 = container.querySelector('#tab-1') as HTMLElement;
+
+      // Initial state (assuming renderGistDetail was called with first tab active)
+      tab0.setAttribute('tabindex', '0');
+      tab1.setAttribute('tabindex', '-1');
+
+      tab1.click();
+
+      await vi.waitFor(() => {
+        expect(tab1.getAttribute('tabindex')).toBe('0');
+        expect(tab0.getAttribute('tabindex')).toBe('-1');
+      });
+    });
+
+    it('supports keyboard navigation between tabs', async () => {
+      const gistStoreModule = await import('../../src/stores/gist-store');
+      vi.mocked(gistStoreModule.default.getGist).mockReturnValue({
+        id: 'gist-1',
+        files: { 'a.ts': {}, 'b.ts': {}, 'c.ts': {} },
+      } as any);
+
+      // Re-render with 3 tabs for Home/End test
+      container.innerHTML = `
+        <div class="gist-detail">
+          <div class="file-tabs" role="tablist">
+            <button class="file-tab active" id="tab-0" tabindex="0">A</button>
+            <button class="file-tab" id="tab-1" tabindex="-1">B</button>
+            <button class="file-tab" id="tab-2" tabindex="-1">C</button>
+          </div>
+        </div>
+      `;
+      const tab0 = container.querySelector('#tab-0') as HTMLElement;
+      const tab1 = container.querySelector('#tab-1') as HTMLElement;
+      const tab2 = container.querySelector('#tab-2') as HTMLElement;
+
+      bindDetailEvents(container, { onBack, onEdit, onViewRevision });
+
+      // Mock focus because JSDOM focus handling can be tricky
+      const focusSpy0 = vi.spyOn(tab0, 'focus');
+      const focusSpy1 = vi.spyOn(tab1, 'focus');
+      const focusSpy2 = vi.spyOn(tab2, 'focus');
+
+      const tabList = container.querySelector('.file-tabs') as HTMLElement;
+
+      // ArrowRight from 0 to 1
+      tab0.focus();
+      tabList.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+      expect(focusSpy1).toHaveBeenCalled();
+
+      // ArrowLeft from 1 to 0
+      tab1.focus();
+      tabList.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }));
+      expect(focusSpy0).toHaveBeenCalled();
+
+      // End to last tab
+      tab0.focus();
+      tabList.dispatchEvent(new KeyboardEvent('keydown', { key: 'End', bubbles: true }));
+      expect(focusSpy2).toHaveBeenCalled();
+
+      // Home to first tab
+      tab2.focus();
+      tabList.dispatchEvent(new KeyboardEvent('keydown', { key: 'Home', bubbles: true }));
+      expect(focusSpy0).toHaveBeenCalled();
     });
 
     it('copies content to clipboard when copy button is clicked', async () => {

--- a/tests/unit/home.test.ts
+++ b/tests/unit/home.test.ts
@@ -133,6 +133,12 @@ describe('Home Route', () => {
       const searchInput = container.querySelector('#gist-search') as HTMLInputElement;
       expect(searchInput?.value).toBe('test query');
     });
+
+    it('has accessibility aria-label on search input', () => {
+      render(container);
+      const searchInput = container.querySelector('#gist-search');
+      expect(searchInput?.getAttribute('aria-label')).toBe('Search gists');
+    });
   });
 
   // ── Gist List ──────────────────────────────────────────────────────────


### PR DESCRIPTION
### 🎨 Palette: Accessibility Improvements for Tabs and Search

#### 💡 What
This PR enhances the accessibility of the Gist Detail and Home views by improving keyboard navigation and screen reader support.

#### 🎯 Why
- **Keyboard users** previously couldn't navigate between multiple files in a Gist using standard arrow key patterns.
- **Screen reader users** lacked descriptive labels for the "Back" button in the revisions view and the search input on the main page.

#### 📸 Before/After
- **Tabs**: Previously, all tabs were in the tab order (tabindex=0). Now, only the active tab is focusable, and users navigate between them using Arrow keys, Home, and End, matching standard ARIA tab patterns.
- **Search**: Added `aria-label="Search gists"` to the home page search input.
- **Back Button**: Added `aria-label="Go back"` to the back button in the revisions list.

#### ♿ Accessibility
- Implemented **Roving Tabindex** for file tabs.
- Added missing **ARIA labels** to interactive elements.
- Follows **WCAG 2.2 AA** patterns for tabbed interfaces.

#### Verification
- Passed `pnpm run check` and `pnpm run test:unit`.
- Passed `./scripts/quality_gate.sh`.
- Visually and functionally verified with a Playwright script demonstrating keyboard interactions and presence of ARIA labels.

---
*PR created automatically by Jules for task [7922615182350007493](https://jules.google.com/task/7922615182350007493) started by @d-o-hub*